### PR TITLE
Support multiple existential outputs in derive_generator/derive_enumerator

### DIFF
--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -9,6 +9,12 @@ register_option specimen.debug : Bool := {
   descr := "enable debug messages from Specimen"
 }
 
+/-- When true, the scheduler produces maximally many outputs per hypothesis step -/
+register_option specimen.multiOutput : Bool := {
+  defValue := false
+  descr := "allow multi-output production steps in derived generators"
+}
+
 /-- Global flag for enabling/diabling debug messages -/
 def globalDebugFlag : Bool := false
 

--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -15,8 +15,12 @@ register_option specimen.multiOutput : Bool := {
   descr := "allow multi-output production steps in derived generators"
 }
 
-/-- Global flag for enabling/diabling debug messages -/
+/-- Global flag for enabling/disabling debug messages -/
 def globalDebugFlag : Bool := false
+
+/-- Conditional debug trace for pure contexts. Use as `let _ := schedTrace "msg"`. -/
+macro "schedTrace " msg:interpolatedStr(term) : term =>
+  `(if globalDebugFlag then dbg_trace $msg; () else ())
 
 /-- Determines whether the `specimen.debug` Option flag is set -/
 def inDebugMode [Monad m] [MonadOptions m] : m Bool := do

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -182,7 +182,7 @@ def deriveScheduledChecker' (_args : Array Expr)
 
       if (not requiredInstances.isEmpty) then
         let deduplicatedInstances := List.eraseDups requiredInstances.toList
-        logWarning m!"Required typeclass instances (please derive these first if they aren't already defined):\n{deduplicatedInstances}"
+        trace[plausible.deriving.arbitrary] m!"Required typeclass instances (please derive these first if they aren't already defined):\n{deduplicatedInstances}"
 
       -- Collect all the base / inductive checkers into two Lean list terms
       -- Base checkers are invoked when `size = 0`, inductive checkers are invoked when `size > 0`

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -158,7 +158,8 @@ def deriveScheduledChecker' (_args : Array Expr)
           -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
           -- (where each term represents a typeclass instance)
           let (subChecker, instances) ← StateT.run (s := #[]) (do
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) unifyState.outputType freshSizePrimeName
+            let recType := unifyState.outputTypes.headD (mkConst ``Bool)
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) recType freshSizePrimeName
             MExp.mexpToTSyntax mexp (deriveSort := .Checker))
 
           requiredInstances := requiredInstances ++ instances

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -650,11 +650,8 @@ def deriveConstrainedProducer
   let argNamesTypes := argNames.zip argTypes
 
   -- The output type for code generation — for multiple outputs, use a right-nested product type
-  let rec mkProdType : List Expr → TermElabM Expr
-    | [] => throwError "no output types"
-    | [t] => pure t
-    | t :: ts => do let rest ← mkProdType ts; mkAppM ``Prod #[t, rest]
-  let outputType ← mkProdType outputTypes.toList
+  let outputType ← tupleOfListM (throwError "no output types")
+    (fun t rest => mkAppM ``Prod #[t, rest]) outputTypes.toList
 
   -- Add the name & type of each argument of the inductive relation to the `LocalContext`
   -- Then, derive `baseProducers` & `inductiveProducers` (the code for the sub-producers
@@ -767,8 +764,8 @@ def deriveConstrainedProducer
     constrainingInductive
     inductiveLevels
     freshArgIdents
-    freshenedOutputNames
-    outputTypes
+    freshenedOutputNames.toList
+    outputTypes.toList
     producerSort
     localCtx
 

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -26,13 +26,13 @@ open Idents Schedules
 -- https://github.com/QuickChick/QuickChick/blob/internal-rewrite/plugin/newUnifyQC.ml.cppo
 ----------------------------------------------------------------------------------------------------------------------------------
 
-/-- Creates the initial constraint map where all inputs are `Fixed`, while the output & all universally-quantified variables are `Undef`.
+/-- Creates the initial constraint map where all inputs are `Fixed`, while the outputs & all universally-quantified variables are `Undef`.
     - `forAllVariables` is a list of (variable name, variable type) pairs -/
 def mkInitialUnknownMap (inputNames: List Name)
-  (outputName : Name) (outputType : Expr)
+  (outputNamesTypes : List (Name × Expr))
   (forAllVariables : List (Name × Expr)) : UnknownMap :=
   let inputConstraints := inputNames.map (fun n => (n, .Fixed))
-  let outputConstraints := [(outputName, .Undef outputType)]
+  let outputConstraints := outputNamesTypes.map (fun (n, ty) => (n, .Undef ty))
   let filteredForAllVariables := forAllVariables.filter (fun (x, _) => x ∉ inputNames)
   let forAllVarsConstraints := (fun (x, ty) => (x, .Undef ty)) <$> filteredForAllVariables
   Std.HashMap.ofList $ inputConstraints ++ outputConstraints ++ forAllVarsConstraints
@@ -40,23 +40,24 @@ def mkInitialUnknownMap (inputNames: List Name)
 /-- Creates the initial `UnifyState` for a producer, with the `UnifyState` corresponding to a constructor of an inductive relation.
     The arguments to this function are:
     - `inputNames`: the names of all inputs to the producer
-    - `outputName`, `outputType`: name & type of the output (variable to be produced)
-  - `forAllVariables`: the names & types for universally-quantified variables in the constructor's type
+    - `outputNamesTypes`: names & types of the outputs (variables to be produced)
+    - `forAllVariables`: the names & types for universally-quantified variables in the constructor's type
     - `hypotheses`: the hypotheses for the constructor (represented as a constructor name applied to some list of arguments) -/
 def mkProducerInitialUnifyState (inputNames : List Name)
-  (outputName : Name)
-  (outputType : Expr)
+  (outputNamesTypes : List (Name × Expr))
   (forAllVariables : List (Name × Expr))
   (hypotheses : List (Name × List ConstructorExpr)) : UnifyState :=
+  let outputNames := outputNamesTypes.map Prod.fst
+  let outputTypes := outputNamesTypes.map Prod.snd
   let forAllVarNames := Prod.fst <$> forAllVariables
-  let constraints := mkInitialUnknownMap inputNames outputName outputType forAllVariables
-  let unknowns := Std.HashSet.ofList (outputName :: (inputNames ++ forAllVarNames))
+  let constraints := mkInitialUnknownMap inputNames outputNamesTypes forAllVariables
+  let unknowns := Std.HashSet.ofList (outputNames ++ inputNames ++ forAllVarNames)
   { constraints := constraints
     equalities := ∅
     patterns := []
     unknowns := unknowns
-    outputName := outputName
-    outputType := outputType
+    outputNames := outputNames
+    outputTypes := outputTypes
     inputNames := inputNames
     hypotheses := hypotheses }
 
@@ -81,7 +82,8 @@ def mkCheckerInitialUnifyState (inputNames : List Name)
     constraints := constraints
     unknowns := unknowns
     inputNames := inputNames
-    hypotheses := hypotheses }
+    hypotheses := hypotheses
+  }
 
 /-- Converts a expression `e` to a *constructor expression* `C r1 … rn`,
     where `C` is a constructor and the `ri` are arguments,
@@ -262,7 +264,7 @@ def getScheduleSort (conclusion : HypothesisExpr)
     - Note: it is the caller's responsibility to check that `conclusion` does indeed contain
       a non-trivial function application (e.g. by using `containsNonTrivialFuncApp`) -/
 def linearizeAndFlatten
-  (hypotheses : Array Expr) (conclusion : Expr) (outputIndex : Option Nat) (localCtx : LocalContext) :
+  (hypotheses : Array Expr) (conclusion : Expr) (outputIndices : List Nat) (localCtx : LocalContext) :
   UnifyM (Array Expr × Expr × List (Name × Expr) × LocalContext) := do
   -- Find all sub-terms which are non-trivial function applications
   let funcAppExprs ← collectUnmatchableProperSubterms conclusion
@@ -293,16 +295,16 @@ def linearizeAndFlatten
       additionalHyps := additionalHyps.push newHyp
 
     trace[plausible.deriving.arbitrary] m!"Original Conclusion: {conclusion}"
-    let conclusion := replaceExprsRecursivelyOnce conclusion funcCallEqualities none
+    let conclusion := replaceExprsRecursivelyOnce conclusion funcCallEqualities []
     trace[plausible.deriving.arbitrary] m!"Rewritten Conclusion after flattening: {conclusion}"
 
     let functionsNewTypedVars := freshUnknownsAndTypes
     let functionsNewHyps := additionalHyps
 
     -- Count variable occurrences to find nonlinear patterns
-    let varOccurrences := collectFVarOccurrences conclusion outputIndex
+    let varOccurrences := collectFVarOccurrences conclusion outputIndices
 
-    trace[plausible.deriving.arbitrary] m!"varOccurences: {repr varOccurrences.toList} \n expr: {conclusion} \n outputIndex {outputIndex}"
+    trace[plausible.deriving.arbitrary] m!"varOccurences: {repr varOccurrences.toList} \n expr: {conclusion} \n outputIndices {outputIndices}"
 
     let nonlinearVars := varOccurrences.toList.filter (fun (_, count) => count > 1)
 
@@ -338,7 +340,7 @@ def linearizeAndFlatten
     let updatedHypotheses := hypotheses ++ additionalHyps ++ functionsNewHyps
 
     trace[plausible.deriving.arbitrary] m!"Flattened Conclusion: {conclusion}"
-    let rewrittenConclusion := replaceExprsRecursivelyOnce conclusion nonlinearVarEqualities outputIndex
+    let rewrittenConclusion := replaceExprsRecursivelyOnce conclusion nonlinearVarEqualities outputIndices
     trace[plausible.deriving.arbitrary] m!"Rewritten Conclusion after linearizing: {rewrittenConclusion}"
 
 
@@ -393,8 +395,8 @@ def scheduleLT (a b : List ScheduleStep) := scheduleStepsScore a < scheduleSteps
         listed in order, which coincides with `inputNames ∪ { outputName }` -/
 def getScheduleForInductiveRelationConstructor
   (inductiveName : Name) (ctorName : Name) (inputNames : List Name)
-  (deriveSort : DeriveSort) (outputNameTypeOption : Option (Name × Expr × Nat)) (unknownsArray : Array Unknown) (localCtx : LocalContext) (recFnName : Name := defaultRecFnName deriveSort) : UnifyM Schedule := do
-  trace[plausible.deriving.arbitrary] "Schedule requested for inductive {inductiveName}'s constructor, {ctorName} with inputs: {inputNames} and variables: {unknownsArray}, outputInfo: {outputNameTypeOption}"
+  (deriveSort : DeriveSort) (outputNameTypeOption : Option (List (Name × Expr × Nat))) (unknownsArray : Array Unknown) (localCtx : LocalContext) (recFnName : Name := defaultRecFnName deriveSort) : UnifyM Schedule := do
+  trace[plausible.deriving.arbitrary] "Schedule requested for inductive {inductiveName}'s constructor, {ctorName} with inputs: {inputNames} and variables: {unknownsArray}"
 
   let ctorInfo ← getConstInfoCtor ctorName
   let ctorType := ctorInfo.type
@@ -427,14 +429,16 @@ def getScheduleForInductiveRelationConstructor
       | none => some tyExpr
       | some _ => none)
 
-    let outputIndex := (fun a => a.snd.snd) <$> outputNameTypeOption
+    let outputIndices := match outputNameTypeOption with
+      | some outputs => outputs.map (fun (_, _, idx) => idx)
+      | none => []
 
     -- For each function call in the cocnlusion, rewrite it by introducing a fresh variable
     -- equal to the result of the function call, and adding an extra hypothesis asserting equality
     -- between the function call and the variable.
     -- `freshNamesAndTypes` is a list containing the names & types of the fresh variables produced during this procedure.
     let (updatedHypotheses, updatedConclusion, freshNamesAndTypes, updatedLocalCtx) ←
-      linearizeAndFlatten hypotheses conclusion outputIndex (← getLCtx)
+      linearizeAndFlatten hypotheses conclusion outputIndices (← getLCtx)
     -- Enter the updated `LocalContext` containing the fresh variable that was created when rewriting the conclusion
     withLCtx' updatedLocalCtx (do
       let hypothesisExprs := (← monadLift (updatedHypotheses.toList.mapM (exprToHypothesisExpr ctorName))).toArray
@@ -447,7 +451,9 @@ def getScheduleForInductiveRelationConstructor
         | .Generator | .Enumerator =>
            match outputNameTypeOption with
           | none => throwError "Output name & type not specified when deriving producer"
-          | some (outputName, outputType, _outputIndex) => pure $ mkProducerInitialUnifyState inputNames outputName outputType forAllVars hypothesisExprs.toList
+          | some outputs =>
+            let outputNamesTypes := outputs.map (fun (n, ty, _) => (n, ty))
+            pure $ mkProducerInitialUnifyState inputNames outputNamesTypes forAllVars hypothesisExprs.toList
         | .Checker | .Theorem => pure $ mkCheckerInitialUnifyState inputNames forAllVars hypothesisExprs.toList
 
 
@@ -494,9 +500,10 @@ def getScheduleForInductiveRelationConstructor
         | .Generator | .Enumerator =>
           match outputNameTypeOption with
           | none => throwError "Error: output name & type not specified when deriving producer"
-          | some (outputName, _) =>
-          let outputIdx := unknowns.idxOf outputName
-          pure ([outputName], (inductiveName, [outputIdx]))
+          | some outputs =>
+          let outputNames := outputs.map (fun (n, _, _) => n)
+          let outputIdxs := outputNames.map (fun n => unknowns.idxOf n)
+          pure (outputNames, (inductiveName, outputIdxs))
         | .Checker | .Theorem => pure ([], (inductiveName, []))
 
       -- Determine the appropriate `ScheduleSort` (right now we only produce `ScheduleSort`s for `Generator`s)
@@ -524,6 +531,7 @@ def getScheduleForInductiveRelationConstructor
       trace[plausible.deriving.arbitrary] m!"Fixed Vars: {repr fixedVars}"
 
       -- Compute all possible checker schedules for this constructor
+      let multiOutput := Lean.Option.get (← getOptions) specimen.multiOutput
       let possibleSchedules := possibleSchedules
         (vars := updatedForAllVars)
         (hypotheses := hypothesisExprs.toList)
@@ -532,6 +540,7 @@ def getScheduleForInductiveRelationConstructor
         recCall
         fixedVars
         recFnName
+        multiOutput
 
       match possibleSchedules with
       | .lnil => throwError m!"Unable to compute any possible schedules"
@@ -577,28 +586,28 @@ def getScheduleForInductiveRelationConstructor
     This function takes the following as arguments:
     - The name of the inductive relation `inductiveName`
     - The constructor name `ctorName`
-    - The name (`outputName`) and type (`outputType`) of the output (value to be generated)
+    - The names, types, and indices of the outputs (values to be generated)
     - The names of inputs `inputNames` (arguments to the generator)
     - An array of `unknowns` (the arguments to the inductive relation)
-      + Note: `unknowns == inputNames ∪ { outputName }`, i.e. `unknowns` contains all args to the inductive relation
-        listed in order, which coincides with `inputNames ∪ { outputName }` -/
+      + Note: `unknowns == inputNames ∪ outputNames`, i.e. `unknowns` contains all args to the inductive relation
+        listed in order, which coincides with `inputNames ∪ outputNames` -/
 def getProducerScheduleForInductiveConstructor
-  (inductiveName : Name) (ctorName : Name) (outputName : Name) (outputType : Expr) (outputIndex : Nat) (inputNames : List Name)
+  (inductiveName : Name) (ctorName : Name) (outputNamesTypesIndices : List (Name × Expr × Nat)) (inputNames : List Name)
   (unknowns : Array Unknown) (deriveSort : DeriveSort) (localCtx : LocalContext) (recFnName : Name := defaultRecFnName deriveSort) : UnifyM Schedule :=
-  getScheduleForInductiveRelationConstructor inductiveName ctorName inputNames deriveSort (some (outputName, outputType, outputIndex)) unknowns localCtx recFnName
+  getScheduleForInductiveRelationConstructor inductiveName ctorName inputNames deriveSort (some outputNamesTypesIndices) unknowns localCtx recFnName
 
 
 /-- Produces an instance of a typeclass for a constrained producer (either `ArbitrarySizedSuchThat` or `EnumSizedSuchThat`).
     The arguments to this function are:
 
-    - `outputVar` and `outputType` are the name & type of the value to be generated,
+    - `outputVars` and `outputTypes` are the names & types of the values to be generated,
     - `constrainingInductive` is the inductive predicate constraining the generated values need to satisfy
     - `constrArgs` are the arguments of the inductive predicate
     - `deriveSort` is the sort of function we are deriving (either `.Generator` or `.Enumerator`) -/
 def deriveConstrainedProducer
   (_args : Array Expr)
-  (outputVar : Expr)
-  (outputType : Expr)
+  (outputVars : Array Expr)
+  (outputTypes : Array Expr)
   (constrainingInductive : Name)
   (inductiveLevels : List Level)
   (constrArgs : Array Expr)
@@ -608,16 +617,15 @@ def deriveConstrainedProducer
 
   let inductiveName := constrainingInductive
 
-  -- Figure out the name and type of the value we wish to generate (the "output")
-  let _outputName := outputVar.fvarId!
-  -- Find the index of the output variable in the inductive application.
-  -- The output is the argument that is not one of the fun-bound input variables.
-  let inputFVars := _args.map Expr.fvarId!
-  let outputIdxOpt := constrArgs.findIdx? fun arg =>
-    !arg.isFVar || !inputFVars.contains arg.fvarId!
-  if let .none := outputIdxOpt then
-    throwError m!"cannot find index of {outputVar}, try specifying the implicit arguments"
-  let outputIdx := Option.get! outputIdxOpt
+  -- Find the indices of the output variables in the inductive application.
+  let outputFVars := outputVars.map Expr.fvarId!
+  let mut outputIdxs : Array Nat := #[]
+  for i in [:constrArgs.size] do
+    let arg := constrArgs[i]!
+    if arg.isFVar && outputFVars.contains arg.fvarId! then
+      outputIdxs := outputIdxs.push i
+  if outputIdxs.isEmpty then
+    throwError m!"cannot find output indices, try specifying the implicit arguments"
 
   -- Obtain Lean's `InductiveVal` data structure, which contains metadata about the inductive relation
   let inductiveVal ← getConstInfoInduct inductiveName
@@ -629,23 +637,30 @@ def deriveConstrainedProducer
   -- we pop the last element (`Prop`) from `inductiveTypeComponents`
   let argTypes := inductiveTypeComponents.pop
 
-  -- Extract the name of each argument. The output position may not be an fvar
+  -- Extract the name of each argument. Output positions may not be fvars
   -- (e.g., when the output type depends on fun-bound variables), so use the
   -- output variable's name there.
   let argNames ← constrArgs.mapIdxM
     (fun i (ident : Expr) =>
       if ident.isFVar then
         ident.fvarId!.getUserName
-      else if i == outputIdx then
-        outputVar.fvarId!.getUserName
+      else if let some outIdx := outputIdxs.findIdx? (· == i) then
+        outputVars[outIdx]!.fvarId!.getUserName
       else throwError m!"{ident} is expected to be a variable.")
   let argNamesTypes := argNames.zip argTypes
+
+  -- The output type for code generation — for multiple outputs, use a right-nested product type
+  let rec mkProdType : List Expr → TermElabM Expr
+    | [] => throwError "no output types"
+    | [t] => pure t
+    | t :: ts => do let rest ← mkProdType ts; mkAppM ``Prod #[t, rest]
+  let outputType ← mkProdType outputTypes.toList
 
   -- Add the name & type of each argument of the inductive relation to the `LocalContext`
   -- Then, derive `baseProducers` & `inductiveProducers` (the code for the sub-producers
   -- that are invoked when `size = 0` and `size > 0` respectively),
-  -- and obtain freshened versions of the output variable / arguments (`freshenedOutputName`, `freshArgIdents`)
-  let (baseProducers, inductiveProducers, freshenedOutputName, freshArgIdents, localCtx) ←
+  -- and obtain freshened versions of the output variables / arguments (`freshenedOutputNames`, `freshArgIdents`)
+  let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, localCtx) ←
     withLocalDeclsDND argNamesTypes (fun _ => do
       let mut localCtx ← getLCtx
       let mut freshUnknowns := #[]
@@ -658,13 +673,19 @@ def deriveConstrainedProducer
         localCtx := localCtx.renameUserName argName freshArgName
         freshUnknowns := freshUnknowns.push freshArgName
 
-      -- Since the `output` also appears as an argument to the inductive relation,
-      -- we also need to freshen its name
-      let freshenedOutputName := freshUnknowns[outputIdx]!
+      -- Since the outputs also appear as arguments to the inductive relation,
+      -- we also need to freshen their names
+      let freshenedOutputNames := outputIdxs.map (fun idx => freshUnknowns[idx]!)
 
-      -- Each argument to the inductive relation (except the one at `outputIdx`)
+      -- Each argument to the inductive relation (except those at output indices)
       -- is treated as an input
-      let freshenedInputNamesExcludingOutput := (Array.eraseIdx! freshUnknowns outputIdx).toList
+      let freshenedInputNamesExcludingOutput := freshUnknowns.toList.filter
+        (fun n => freshenedOutputNames.toList.all (· != n))
+
+      -- Build the list of (outputName, outputType, outputIndex) triples
+      let outputNamesTypesIndices : List (Name × Expr × Nat) :=
+        (List.range outputIdxs.size).map (fun i =>
+          (freshenedOutputNames[i]!, outputTypes[i]!, outputIdxs[i]!))
 
       let mut nonRecursiveProducers := #[]
       let mut recursiveProducers := #[]
@@ -683,8 +704,8 @@ def deriveConstrainedProducer
       let mut requiredInstances := #[]
       for ctorName in inductiveVal.ctors do
         let scheduleOption ← (UnifyM.runInMetaM
-          (getProducerScheduleForInductiveConstructor inductiveName ctorName freshenedOutputName
-            outputType outputIdx freshenedInputNamesExcludingOutput freshUnknowns deriveSort localCtx freshRecFnName)
+          (getProducerScheduleForInductiveConstructor inductiveName ctorName outputNamesTypesIndices
+            freshenedInputNamesExcludingOutput freshUnknowns deriveSort localCtx freshRecFnName)
             emptyUnifyState)
         match scheduleOption with
         | some schedule =>
@@ -737,7 +758,7 @@ def deriveConstrainedProducer
       let baseProducers ← `([$nonRecursiveProducers,*])
       let inductiveProducers ← `([$nonRecursiveProducers,*, $recursiveProducers,*])
 
-      return (baseProducers, inductiveProducers, freshenedOutputName, Lean.mkIdent <$> freshUnknowns, localCtx))
+      return (baseProducers, inductiveProducers, freshenedOutputNames, Lean.mkIdent <$> freshUnknowns, localCtx))
 
   -- Create an instance of the appropriate producer typeclass
   mkConstrainedProducerTypeClassInstance
@@ -746,40 +767,53 @@ def deriveConstrainedProducer
     constrainingInductive
     inductiveLevels
     freshArgIdents
-    freshenedOutputName
-    outputType
+    freshenedOutputNames
+    outputTypes
     producerSort
     localCtx
 
 
 private def deriveArbitrarySuchThatInstance'
   (args : Array Expr)
-  (outputVar : Expr)
-  (outputType : Expr)
+  (outVars : Array Expr)
+  (outTypes : Array Expr)
   (constrainingInductive : Name)
   (inductiveLevels : List Level)
   (constrArgs : Array Expr) :
   TermElabM (TSyntax `command) := do
-  deriveConstrainedProducer args outputVar outputType constrainingInductive inductiveLevels constrArgs (deriveSort := .Generator)
+  deriveConstrainedProducer args outVars outTypes constrainingInductive inductiveLevels constrArgs (deriveSort := .Generator)
 
+/-- Peels nested existentials from `∃ x₁, ∃ x₂, ..., P x₁ x₂ ...`, calling `action` inside
+    the nested lambdaTelescope scopes so that fvars remain in scope. -/
+private partial def peelExistentialsAux (body : Expr) (outVars : Array Expr) (outTypes : Array Expr)
+    (action : Expr → Array Expr → Array Expr → TermElabM α) : TermElabM α := do
+  match body.app2? ``Exists with
+  | .some (outTy, innerBody) =>
+    let innerBody ← whnf innerBody
+    lambdaTelescope innerBody fun binders innerBody' => do
+      if h : binders.size > 0 then
+        peelExistentialsAux innerBody' (outVars.push binders[0]) (outTypes.push outTy) action
+      else
+        action body outVars outTypes
+  | .none => action body outVars outTypes
+
+/-- Parses the user-supplied derivation constraint, extracting the input args, output vars, output types,
+    constraining inductive name, its levels, and its arguments. Supports multiple existential outputs. -/
 private def withParsedDerivingArgs (input : Expr)
   (action :
-    (args : Array Expr) → (out : Expr) → (outTy : Expr) →
+    (args : Array Expr) → (outVars : Array Expr) → (outTypes : Array Expr) →
     (constrInd : Name) → (constrLevels : List Level) → (constrArgs : Array Expr) → TermElabM α) : TermElabM α :=
   lambdaTelescope input <|
   fun args body => do
-  let .some (outTy, body) := body.app2? ``Exists | throwError m!"Error in parsing constraint: {body} is not of the form ∃ x, P."
-  let body ← whnf body
-  lambdaTelescope body <|
-  fun outVars body =>
-  body.withApp <|
+  peelExistentialsAux body #[] #[] fun innerBody outVars outTypes => do
+  if outVars.isEmpty then
+    throwError m!"Error in parsing constraint: {body} is not of the form ∃ x, P."
+  innerBody.withApp <|
   fun ind indArgs => do
-  if outVars.size ≠ 1 then throwError m!"Error in parsing constraint: Expected a single output variable, got {outVars}."
-  let out := outVars[0]!
   if !ind.isConst then throwError m!"Error in parsing constraint: {ind} is expected to be a constant."
   let indName := ind.constName!
   let indLevels := ind.constLevels!
-  action args out outTy indName indLevels indArgs
+  action args outVars outTypes indName indLevels indArgs
 
 /-- Derives an instance of the `ArbitrarySuchThat` typeclass,
     where `outputVar` and `outputTypeSyntax` are the name & type of the value to be generated,
@@ -788,9 +822,9 @@ def deriveArbitrarySuchThatInstance (tm : Term) : TermElabM Command := do
   let e ← elabTerm tm .none
   withParsedDerivingArgs e deriveArbitrarySuchThatInstance'
 
-def deriveEnumSuchThatInstance' (args : Array Expr) (outputVar : Expr) (outputType : Expr)
+def deriveEnumSuchThatInstance' (args : Array Expr) (outVars : Array Expr) (outTypes : Array Expr)
   (constrainingProp : Name) (inductiveLevels : List Level) (constrArgs : Array Expr) : TermElabM (TSyntax `command) :=
-  deriveConstrainedProducer args outputVar outputType constrainingProp inductiveLevels constrArgs (deriveSort := .Enumerator)
+  deriveConstrainedProducer args outVars outTypes constrainingProp inductiveLevels constrArgs (deriveSort := .Enumerator)
 
 /-- Derives an instance of the `EnumSuchThat` typeclass,
     where `outputVar` and `outputTypeSyntax` are the name & type of the value to be generated,
@@ -823,7 +857,24 @@ def elabDeriveGenerator : CommandElab := fun stx => do
 
   | _ => throwUnsupportedSyntax
 
-/-- Command for deriving a constrained generator for an inductive relation -/
+/-- Command for deriving a constrained generator with multi-output hypothesis steps -/
+syntax (name := generator_multi_deriver) "derive_generator_multi" term : command
+
+/-- Elaborator for `derive_generator_multi` — same as `derive_generator` but allows each
+    hypothesis to produce maximally many outputs at once (requires multi-output instances). -/
+@[command_elab generator_multi_deriver]
+def elabDeriveGeneratorMulti : CommandElab := fun stx => do
+  match stx with
+  | `(derive_generator_multi $descr:term) => do
+    withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
+      let typeClassInstance ← liftTermElabM <| deriveArbitrarySuchThatInstance descr
+      let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this generator: ")
+      elabCommand typeClassInstance
+  | _ => throwUnsupportedSyntax
+
+/-- Command for deriving a constrained enumerator for an inductive relation -/
 syntax (name := enumerator_deriver) "derive_enumerator" term : command
 
 /-- Elaborator for the `derive_generator` command which derives a constrained generator

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -5,6 +5,7 @@ import Specimen.UnificationMonad
 import Specimen.MakeConstrainedProducerInstance
 import Specimen.LazyList
 import Specimen.SearchTree
+import Specimen.Debug
 import Lean.Util.SCC
 
 namespace Schedules
@@ -971,6 +972,11 @@ def List.permutations {α : Type u} : List α → List (List α)
   | x :: xs => ((List.permutations xs).flatMap fun perm =>
     (List.range (perm.length + 1)).map fun i => perm.take i ++ [x] ++ perm.drop i)
 
+/-- Evaluates one scheduling choice for a hypothesis: `out` are the output variable groups
+    produced by satisfying the hypothesis, `bound` are variables bound arbitrarily beforehand.
+    Extends the environment with bound vars, partitions remaining hypotheses into pre/post-checks
+    around the produce step. Returns `none` if invalid (multiple outputs in single-output mode,
+    or no outputs with non-empty bound). -/
 private def processChoice {α v} [BEq v] [Hashable v] (multiOutput : Bool) (hyp : α)
         (out bound : List (List v)) (some_bound_output_indices : List (List v))
         (always_bound_variables : List v) (rest : List (α × List (List v) × List v))
@@ -1005,6 +1011,10 @@ private def findMins [Ord β] (l : List α) (score : α → β) : List α :=
   | [] => []
   | a :: as => aux as [a] (score a)
 
+/-- Lazily enumerates generator schedules using branch-and-bound pruning.
+    Explores permutations of hypothesis orderings chunked by connected components,
+    pruning branches whose lower-bound score exceeds the best found so far.
+    Returns a lazy list of valid schedules sorted by quality (best first). -/
 private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr α] [Repr v] [Hashable v] (vars : List v) (matchableVars : List v) (hypComps : List (LazyList (List (α × List (List v) × List v)))) (env : List v) (numHyps : Nat) (multiOutput : Bool := false)
   : LazyList (List (PreScheduleStep α v)) :=
   let matchableSet := Std.HashSet.ofList matchableVars
@@ -1042,20 +1052,20 @@ private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr
         let lowerBound := estimateLowerBound currentScore remainingHyps
         let envKey := ((List.eraseDups currentEnv) |>.mergeSort (fun a b => compare a b |>.isLE))
         let dominatingScore := envMemo[envKey]?.getD componentBest
-        -- dbg_trace "processPerm: remainingHyps={remainingHyps}, currentScore={repr currentScore}, lowerBound={repr lowerBound}, runningBest={repr runningComponentBest}, dominatingScore={repr dominatingScore}"
+        let _ := schedTrace "processPerm: remainingHyps={remainingHyps}, currentScore={repr currentScore}, lowerBound={repr lowerBound}, runningBest={repr runningComponentBest}, dominatingScore={repr dominatingScore}"
         if lowerBound > runningComponentBest then
-          -- dbg_trace "PRUNED: lowerBound > runningComponentBest ({repr lowerBound} >= {repr runningComponentBest}) \n"
+          let _ := schedTrace "PRUNED: lowerBound > runningComponentBest ({repr lowerBound} >= {repr runningComponentBest})"
           .lnil
         else if dominatingScore < currentScore then
-          -- dbg_trace "PRUNED: dominatingScore < currentScore ({repr dominatingScore} < {repr currentScore}) \n"
+          let _ := schedTrace "PRUNED: dominatingScore < currentScore ({repr dominatingScore} < {repr currentScore})"
           .lnil
         else
         match currentPerm with
         | [] =>
-          -- dbg_trace "BASE CASE: returning final schedule with score {repr currentScore}"
+          let _ := schedTrace "BASE CASE: returning final schedule with score {repr currentScore}"
           pure ((sched ++ currentSched, currentEnv), (currentScore, envMemo))
         | (hyp, potential_output_indices, always_bound_variables) :: rest =>
-          -- dbg_trace "PROCESSING hyp: {repr hyp}, potential_outputs: {repr potential_output_indices.length}, always_bound: {repr always_bound_variables.length}"
+          let _ := schedTrace "PROCESSING hyp: {repr hyp}, potential_outputs: {repr potential_output_indices.length}, always_bound: {repr always_bound_variables.length}"
           let envMemo := if currentScore < dominatingScore then envMemo.insert envKey currentScore else envMemo
           let (some_bound_output_indices, all_unbound_output_indices) := potential_output_indices.partition
             (fun l =>
@@ -1066,7 +1076,7 @@ private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr
             else
               ([],all_unbound_output_indices) :: (select all_unbound_output_indices |>.toList.map (fun (a,b) => ([a],b)))
           let validChoices := choices.filterMap (fun (out,bound) => processChoice multiOutput hyp out bound some_bound_output_indices always_bound_variables rest currentEnv currentEnvSet)
-          -- dbg_trace "CHOICES: total={choices.length}, valid={validChoices.length}"
+          let _ := schedTrace "CHOICES: total={choices.length}, valid={validChoices.length}"
           let sortedChoices := validChoices.mergeSort (fun (a,_,_,_) (b,_,_,_) => preScheduleStepsScore a ≤ preScheduleStepsScore b)
 
           sequentialFlatMap (LazyList.fromList sortedChoices) (runningComponentBest,envMemo) fun (newSteps, to_be_satisfied', finalEnv, finalEnvSet) (runningComponentBest, envMemo) =>

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -112,6 +112,9 @@ structure ScheduleEnv where
       (e.g. `aux_dec`, `aux_arb`, `aux_enum`). -/
   recFnName : Name
 
+  /-- When true, each hypothesis produces all available outputs at once -/
+  multiOutput : Bool := false
+
 /-- A monad for deriving generator schedules. Under the hood,
     `ScheduleM` is just a reader monad stacked on top of `MetaM`,
     with `ScheduleEnv` serving as the environment for the reader monad. -/
@@ -968,12 +971,12 @@ def List.permutations {α : Type u} : List α → List (List α)
   | x :: xs => ((List.permutations xs).flatMap fun perm =>
     (List.range (perm.length + 1)).map fun i => perm.take i ++ [x] ++ perm.drop i)
 
-private def processChoice {α v} [BEq v] [Hashable v] (hyp : α)
+private def processChoice {α v} [BEq v] [Hashable v] (multiOutput : Bool) (hyp : α)
         (out bound : List (List v)) (some_bound_output_indices : List (List v))
         (always_bound_variables : List v) (rest : List (α × List (List v) × List v))
         (currentEnv : List v) (currentEnvSet : Std.HashSet v)
         : Option (List (PreScheduleStep α v) × List (α × List (List v) × List v) × List v × Std.HashSet v) :=
-  if out.length > 1 || (out.isEmpty && !bound.isEmpty) then none else
+  if (!multiOutput && out.length > 1) || (out.isEmpty && !bound.isEmpty) then none else
   let bound_vars := bound.flatten ++ (always_bound_variables ++ some_bound_output_indices.flatten).filter (!currentEnvSet.contains ·)
   let newEnvSet := bound_vars.foldl (fun s v => s.insert v) currentEnvSet
   let newEnv := bound_vars ++ currentEnv
@@ -1002,7 +1005,7 @@ private def findMins [Ord β] (l : List α) (score : α → β) : List α :=
   | [] => []
   | a :: as => aux as [a] (score a)
 
-private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr α] [Repr v] [Hashable v] (vars : List v) (matchableVars : List v) (hypComps : List (LazyList (List (α × List (List v) × List v)))) (env : List v) (numHyps : Nat)
+private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr α] [Repr v] [Hashable v] (vars : List v) (matchableVars : List v) (hypComps : List (LazyList (List (α × List (List v) × List v)))) (env : List v) (numHyps : Nat) (multiOutput : Bool := false)
   : LazyList (List (PreScheduleStep α v)) :=
   let matchableSet := Std.HashSet.ofList matchableVars
 
@@ -1058,8 +1061,11 @@ private partial def enumSchedulesChunkedWithPruning {α v} [Ord v] [BEq v] [Repr
             (fun l =>
               l.any (fun v => currentEnvSet.contains v && !matchableSet.contains v)
               || l.all matchableSet.contains)
-          let choices := ([],all_unbound_output_indices) :: (select all_unbound_output_indices |>.toList.map (fun (a,b) => ([a],b)))
-          let validChoices := choices.filterMap (fun (out,bound) => processChoice hyp out bound some_bound_output_indices always_bound_variables rest currentEnv currentEnvSet)
+          let choices := if multiOutput then
+              [(all_unbound_output_indices, [])]
+            else
+              ([],all_unbound_output_indices) :: (select all_unbound_output_indices |>.toList.map (fun (a,b) => ([a],b)))
+          let validChoices := choices.filterMap (fun (out,bound) => processChoice multiOutput hyp out bound some_bound_output_indices always_bound_variables rest currentEnv currentEnvSet)
           -- dbg_trace "CHOICES: total={choices.length}, valid={validChoices.length}"
           let sortedChoices := validChoices.mergeSort (fun (a,_,_,_) (b,_,_,_) => preScheduleStepsScore a ≤ preScheduleStepsScore b)
 
@@ -1264,7 +1270,7 @@ private def possiblePreSchedules (vars : List TypedVar) (hypotheses : List Hypot
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1294,12 +1300,12 @@ private def hypothesisToVarExpr (hyp : HypothesisExpr) : List (SearchTree.VarExp
       | _ => SearchTree.VarExpr.Ctor vars
 
 private def possiblePreSchedulesWithAdvancedPruning (vars : List TypedVar) (hypotheses : List HypothesisExpr) (deriveSort : DeriveSort)
-  (recCall : Name × List Nat) (fixedVars : List Name) (recFnName : Name := defaultRecFnName deriveSort) : LazyList ((List (PreScheduleStep HypothesisExpr TypedVar))) × ScheduleEnv :=
+  (recCall : Name × List Nat) (fixedVars : List Name) (recFnName : Name := defaultRecFnName deriveSort) (multiOutput : Bool := false) : LazyList ((List (PreScheduleStep HypothesisExpr TypedVar))) × ScheduleEnv :=
   let typeVars := vars.filterMap fun ⟨v,t⟩ => if t.isSort then some v else none
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, multiOutput ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1311,7 +1317,7 @@ private def possiblePreSchedulesWithAdvancedPruning (vars : List TypedVar) (hypo
                                 SearchTree.enumDependencySatisfyingOrderingsWithAdvancedPruning hypVarMap (fun (h,_) => hypothesisToVarExpr h)
                                   |>.mapLazyList (List.map <| constructHypothesis typeVars))
   let firstChecks := PreScheduleStep.Checks newCheckedHyps.reverse
-  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enumSchedulesChunkedWithPruning remainingVars typeVars connectedHypotheses fixedVars sortedHypotheses.length
+  let lazyPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr Name)) := enumSchedulesChunkedWithPruning remainingVars typeVars connectedHypotheses fixedVars sortedHypotheses.length multiOutput
   let nameTypeMap := List.foldl (fun m ⟨name,ty⟩ => NameMap.insert m name ty) ∅ vars
   let typedPreSchedules : LazyList (List (PreScheduleStep HypothesisExpr TypedVar)) := lazyPreSchedules.mapLazyList ((firstChecks :: ·) ∘ List.map (typePreScheduleStep nameTypeMap))
   (typedPreSchedules, scheduleEnv)
@@ -1327,8 +1333,8 @@ private def possiblePreSchedulesWithAdvancedPruning (vars : List TypedVar) (hypo
     - `recCall`: A pair contianing the name of the inductive relation and a list of indices for output arguments
     - `fixedVars`: A list of fixed variables (i.e. inputs to the inductive relation) -/
 def possibleSchedules (ctorName : Name) (vars : List TypedVar) (hypotheses : List HypothesisExpr) (deriveSort : DeriveSort)
-  (recCall : Name × List Nat) (fixedVars : List Name) (recFnName : Name := defaultRecFnName deriveSort) : LazyList (MetaM (List ScheduleStep × Nat)) := do
-  let (typedPreSchedules, scheduleEnv) := possiblePreSchedulesWithAdvancedPruning vars hypotheses deriveSort recCall fixedVars recFnName
+  (recCall : Name × List Nat) (fixedVars : List Name) (recFnName : Name := defaultRecFnName deriveSort) (multiOutput : Bool := false) : LazyList (MetaM (List ScheduleStep × Nat)) := do
+  let (typedPreSchedules, scheduleEnv) := possiblePreSchedulesWithAdvancedPruning vars hypotheses deriveSort recCall fixedVars recFnName multiOutput
   let prunedImprovingTypedPreSchedules := filterWorse typedPreSchedules preScheduleStepsScore
   let lazySchedules := prunedImprovingTypedPreSchedules.mapLazyList
     ((ReaderT.run . scheduleEnv) ∘ (fun (s,c) => return (← s.flatMapM <| preScheduleStepToScheduleStep ctorName, c)))
@@ -1341,7 +1347,7 @@ private def possibleSchedules' (ctorName : Name) (vars : List TypedVar) (hypothe
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckSteps scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses

--- a/Specimen/GeneratorCombinators.lean
+++ b/Specimen/GeneratorCombinators.lean
@@ -62,9 +62,7 @@ def backtrackFuel (fuel : Nat) (total : Nat) (gs : List (Nat × Gen α)) : Gen �
   | .succ fuel' => do
     let n ← Gen.choose Nat 0 (total - 1) (by omega)
     let (k, g, gs') := pickDrop gs n
-    tryCatch g (fun _ => do
-      let _ ← Rand.next
-      backtrackFuel fuel' (total - k) gs')
+    tryCatch g (fun _ => backtrackFuel fuel' (total - k) gs')
 
 /-- Tries all generators until one returns a `Some` value or all the generators failed once with `None`.
    The generators are picked at random according to their weights (like `frequency` in Haskell QuickCheck),

--- a/Specimen/GeneratorCombinators.lean
+++ b/Specimen/GeneratorCombinators.lean
@@ -62,9 +62,9 @@ def backtrackFuel (fuel : Nat) (total : Nat) (gs : List (Nat × Gen α)) : Gen �
   | .succ fuel' => do
     let n ← Gen.choose Nat 0 (total - 1) (by omega)
     let (k, g, gs') := pickDrop gs n
-    -- Try to generate a value using `g`, if it fails, backtrack with `fuel'`
-    -- and pick one out of the `total - k` remaining generators
-    tryCatch g (fun _ => backtrackFuel fuel' (total - k) gs')
+    tryCatch g (fun _ => do
+      let _ ← Rand.next
+      backtrackFuel fuel' (total - k) gs')
 
 /-- Tries all generators until one returns a `Some` value or all the generators failed once with `None`.
    The generators are picked at random according to their weights (like `frequency` in Haskell QuickCheck),

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -141,6 +141,7 @@ def tupleOfList [Inhabited α] (pair : α → α → α) (l : List α) (default 
   | [x] => x
   | x :: xs => pair x (tupleOfList pair xs default)
 
+
 /-- Converts a list of `Pattern`s to a one single `Pattern` expressed
     as a tuple -/
 def patternTupleOfList (xs : List Pattern) : Pattern :=

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -133,16 +133,13 @@ def okFalse : MExp :=
   ok (.MConst ``false)
 
 
-/-- Converts a `List α` to a "tuple", where the function `pair`
-    is used to create tuples. The `default` element is used when
-    the input list `l` is empty, although for most use-cases,
-    this function will be called with non-empty lists `l`, so `default`
-    will be `none`. -/
+/-- Converts a `List α` to a right-nested "tuple", where the function `pair`
+    is used to create tuples. Produces `(a, (b, c))` for `[a, b, c]`. -/
 def tupleOfList [Inhabited α] (pair : α → α → α) (l : List α) (default : Option α) : α :=
   match l with
   | [] => default.get!
   | [x] => x
-  | x :: xs => List.foldl pair x xs
+  | x :: xs => pair x (tupleOfList pair xs default)
 
 /-- Converts a list of `Pattern`s to a one single `Pattern` expressed
     as a tuple -/
@@ -474,7 +471,7 @@ def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recTyp
       match conclusionMExps with
       | [] => panic! "No outputs being returned in producer schedule"
       | [output] => MExp.MRet output
-      | outputs => tupleOfList (fun e1 e2 => .MApp .allowImplicit (.MConst ``Prod.mk) [e1, e2]) outputs outputs[0]?
+      | outputs => MExp.MRet (tupleOfList (fun e1 e2 => .MApp .allowImplicit (.MConst ``Prod.mk) [e1, e2]) outputs outputs[0]?)
     | .CheckerSchedule => okTrue
     | .TheoremSchedule conclusion typeClassUsed =>
       -- Create a pattern-match on the result of hte checker

--- a/Specimen/MakeConstrainedProducerInstance.lean
+++ b/Specimen/MakeConstrainedProducerInstance.lean
@@ -70,7 +70,8 @@ def findTargetVarIndex (targetVar : FVarId) (args : Array Expr) : (Option Nat) :
     - a list of `inductiveGenerators`, to be invoked when `size > 0`
     - the name of the inductive relation (`inductiveName`)
     - the arguments (`args`) to the inductive relation
-    - the name and type for the value we wish to generate (`targetVar`, `targetType`)
+    - the names and types for the values we wish to generate (`targetVars`, `targetTypes`)
+      + For multiple outputs, the instance is created for the product type
     - the `producerSort`, which determines what typeclass is to be produced
       + If `producerSort = .Generator`, an `ArbitrarySizedSuchThat` instance is produced
       + If `producerSort = .Enumerator`, an `EnumSizedSuchThat` instance is produced
@@ -80,8 +81,8 @@ def mkConstrainedProducerTypeClassInstance
   (inductiveGenerators : TSyntax `term)
   (inductiveName : Name)
   (inductiveLevels : List Level)
-  (args : TSyntaxArray `term) (targetVar : Name)
-  (_targetType : Expr)
+  (args : TSyntaxArray `term) (targetVars : Array Name)
+  (targetTypes : Array Expr)
   (producerSort : ProducerSort)
   (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
     -- Produce a fresh name for the `size` argument for the lambda
@@ -111,8 +112,10 @@ def mkConstrainedProducerTypeClassInstance
     let matchExpr ← mkMatchExpr sizeIdent caseExprs
 
     -- Add parameters for each argument to the inductive relation
-    -- (except the target variable, which we'll filter out later)
+    -- (except the target variables, which we'll filter out later)
     let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
+
+    let targetVarsList := targetVars.toList
 
     -- Inner params are for the inner `aux_arb` / `aux_enum` function
     let mut innerParams := #[]
@@ -121,14 +124,14 @@ def mkConstrainedProducerTypeClassInstance
 
     -- Outer params are for the top-level lambda function which invokes `aux_arb` / `aux_enum`
     let mut outerParams := #[]
-    let mut outputType := none
+    let mut outputTypeSyntaxes : Array (TSyntax `term) := #[]
     let mut typeParams := #[]
     for (paramName, paramType, paramTypeSyntax) in paramInfo do
-      -- Only add a function parameter is the argument to the inductive relation is not the target variable
-      -- (We skip the target variable since that's the value we wish to generate)
+      -- Only add a function parameter if the argument to the inductive relation is not a target variable
+      -- (We skip the target variables since those are the values we wish to generate)
       if paramType.isSort then
         typeParams := typeParams.push paramName
-      if paramName != targetVar then
+      if paramName ∉ targetVarsList then
         let outerParamIdent := mkIdent paramName
         outerParams := outerParams.push outerParamIdent
 
@@ -141,7 +144,28 @@ def mkConstrainedProducerTypeClassInstance
 
         innerParams := innerParams.push innerParam
       else
-        outputType := some paramTypeSyntax
+        outputTypeSyntaxes := outputTypeSyntaxes.push paramTypeSyntax
+
+    -- Build the target type syntax — for multiple outputs, use a right-nested product type
+    let targetTypeSyntax ← do
+      let syns ← if outputTypeSyntaxes.isEmpty then
+        targetTypes.mapM (fun ty => PrettyPrinter.delab ty)
+      else pure outputTypeSyntaxes
+      let rec mkProdType : List (TSyntax `term) → TermElabM (TSyntax `term)
+        | [] => throwError "no output types found"
+        | [t] => pure t
+        | t :: ts => do let rest ← mkProdType ts; `($t × $rest)
+      mkProdType syns.toList
+
+    -- Build the lambda pattern for the typeclass predicate
+    -- For a single output: `fun x => @P args*`
+    -- For multiple outputs: `fun (x₁, (x₂, x₃)) => @P args*` (right-nested)
+    let targetVarPattern : TSyntax `term ← do
+      let rec mkProdPat : List Name → TermElabM (TSyntax `term)
+        | [] => throwError "no output variables"
+        | [v] => `($(Lean.mkIdent v))
+        | v :: vs => do let rest ← mkProdPat vs; `(($(Lean.mkIdent v), $rest))
+      mkProdPat targetVars.toList
 
     -- Figure out which typeclass should be derived
     -- (`ArbitrarySizedSuchThat` for generators, `EnumSizedSuchThat` for enumerators)
@@ -162,10 +186,6 @@ def mkConstrainedProducerTypeClassInstance
       | .Generator => mkFreshAccessibleIdent topLevelLocalCtx `aux_arb
       | .Enumerator => mkFreshAccessibleIdent topLevelLocalCtx `aux_enum
 
-    -- Get the syntax for the target type, it must exist!
-    assert! outputType != none
-    let targetTypeSyntax := outputType.get!
-
     -- Determine the appropriate type of the final producer
     -- (either `Plausible.Gen α` or `ExceptT GenError Enum α`)
     let optionTProducerType ←
@@ -181,7 +201,7 @@ def mkConstrainedProducerTypeClassInstance
     let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
 
     -- Produce an instance of the appropriate typeclass containing the definition for the derived producer
-    `(instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $(mkIdent targetVar) => @$(mkIdent inductiveName) $args*) where
+    `(instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
         $producerTypeClassFunction:ident :=
           let rec $innerFunctionIdent:ident $innerParams* $arbitraryTypeParamInstances:bracketedBinder* : $optionTProducerType :=
             $matchExpr

--- a/Specimen/MakeConstrainedProducerInstance.lean
+++ b/Specimen/MakeConstrainedProducerInstance.lean
@@ -81,8 +81,8 @@ def mkConstrainedProducerTypeClassInstance
   (inductiveGenerators : TSyntax `term)
   (inductiveName : Name)
   (inductiveLevels : List Level)
-  (args : TSyntaxArray `term) (targetVars : Array Name)
-  (targetTypes : Array Expr)
+  (args : TSyntaxArray `term) (targetVars : List Name)
+  (targetTypes : List Expr)
   (producerSort : ProducerSort)
   (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
     -- Produce a fresh name for the `size` argument for the lambda
@@ -115,7 +115,7 @@ def mkConstrainedProducerTypeClassInstance
     -- (except the target variables, which we'll filter out later)
     let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
 
-    let targetVarsList := targetVars.toList
+    let targetVarsList := targetVars
 
     -- Inner params are for the inner `aux_arb` / `aux_enum` function
     let mut innerParams := #[]
@@ -150,12 +150,9 @@ def mkConstrainedProducerTypeClassInstance
     let targetTypeSyntax ← do
       let syns ← if outputTypeSyntaxes.isEmpty then
         targetTypes.mapM (fun ty => PrettyPrinter.delab ty)
-      else pure outputTypeSyntaxes
-      let rec mkProdType : List (TSyntax `term) → TermElabM (TSyntax `term)
-        | [] => throwError "no output types found"
-        | [t] => pure t
-        | t :: ts => do let rest ← mkProdType ts; `($t × $rest)
-      mkProdType syns.toList
+      else pure outputTypeSyntaxes.toList
+      tupleOfListM (throwError "no output types found")
+        (fun t rest => `($t × $rest)) syns
 
     -- Build the lambda pattern for the typeclass predicate
     -- For a single output: `fun x => @P args*`
@@ -165,7 +162,7 @@ def mkConstrainedProducerTypeClassInstance
         | [] => throwError "no output variables"
         | [v] => `($(Lean.mkIdent v))
         | v :: vs => do let rest ← mkProdPat vs; `(($(Lean.mkIdent v), $rest))
-      mkProdPat targetVars.toList
+      mkProdPat targetVars
 
     -- Figure out which typeclass should be derived
     -- (`ArbitrarySizedSuchThat` for generators, `EnumSizedSuchThat` for enumerators)

--- a/Specimen/UnificationMonad.lean
+++ b/Specimen/UnificationMonad.lean
@@ -133,11 +133,11 @@ structure UnifyState where
   /-- A set of all existing `Unknown`s -/
   unknowns : Std.HashSet Unknown
 
-  /-- The name of the output variable (variable to be generated) -/
-  outputName : Name
+  /-- The names of the output variables (variables to be generated) -/
+  outputNames : List Name
 
-  /-- The type of the output variable (variable to be generated) -/
-  outputType : Expr
+  /-- The types of the output variables (variables to be generated) -/
+  outputTypes : List Expr
 
   /-- All inputs (top-level arguments) to the generator -/
   inputNames : List Name
@@ -150,15 +150,15 @@ structure UnifyState where
   deriving Repr
 
 /-- Initial (empty) unification state
-    - Note that the dummy `outputName` and `outputType` are never used
+    - Note that the dummy `outputNames` and `outputTypes` are never used
       (it will be updated when callers invoke the unification algorithm through this monad) -/
 def emptyUnifyState : UnifyState :=
   { constraints := ∅,
     equalities := ∅,
     patterns := [],
     unknowns := ∅,
-    outputName := `dummyOutput,
-    outputType := mkConst `dummyOutputType
+    outputNames := [],
+    outputTypes := []
     inputNames := []
     hypotheses := [] }
 
@@ -442,15 +442,15 @@ partial def updatePattern (k : UnknownMap) (p : Pattern) : UnifyM Pattern := do
   | .LitPattern l => return .LitPattern l
 
 /-- Extends the current state with the contents of the fields in `newState`
-    (Note that the `outputName` and `outputType` of `newStates` are used) -/
+    (Note that the `outputNames` and `outputTypes` of `newState` are used) -/
 def extendState (newState : UnifyState) : UnifyM Unit := do
   modify $ fun s => { s with
     constraints := s.constraints.union newState.constraints
     equalities := s.equalities.union newState.equalities
     patterns := s.patterns ++ newState.patterns
     unknowns := s.unknowns.union newState.unknowns
-    outputName := newState.outputName
-    outputType := newState.outputType
+    outputNames := newState.outputNames
+    outputTypes := newState.outputTypes
     inputNames := s.inputNames ++ newState.inputNames
     hypotheses := s.hypotheses ++ newState.hypotheses
   }

--- a/Specimen/Utils.lean
+++ b/Specimen/Utils.lean
@@ -212,9 +212,9 @@ def foldlWithIndex (f : α → Nat → β → β) (init : β) (l : List α) : β
   aux 0 init l
 
 /-- Recursively collects all free variables in an expression and counts their occurrences.
-    If skipArgIndex is provided and the top-level expression is an application,
-    skips the argument at that index when counting occurrences. -/
-partial def collectFVarOccurrences (e : Expr) (skipArgIndex : Option Nat := none) : FVarIdMap Nat :=
+    If skipArgIndices is non-empty and the top-level expression is an application,
+    skips the arguments at those indices when counting occurrences. -/
+partial def collectFVarOccurrences (e : Expr) (skipArgIndices : List Nat := []) : FVarIdMap Nat :=
   let rec aux (expr : Expr) (acc : FVarIdMap Nat) (isTopLevel : Bool) : FVarIdMap Nat :=
     match expr with
     | .fvar fvarId => acc.insert fvarId (acc.getD fvarId 0 + 1)
@@ -225,7 +225,7 @@ partial def collectFVarOccurrences (e : Expr) (skipArgIndex : Option Nat := none
         Id.run do
           let mut result := acc
           for h : i in [:args.size] do
-            if some i != skipArgIndex then
+            if i ∉ skipArgIndices then
               result := aux args[i] result false
           result
       else
@@ -279,9 +279,9 @@ def lookupAndRemove [BEq α] (key : α) (list : List (α × β)) : Option (β ×
 
 /-- Recursively replaces expressions in an expression tree using a replacement map,
     removing each replacement after it's used.
-    If skipArgIndex is provided and the top-level expression is an application,
-    skips replacement in the argument at that index. -/
-partial def replaceExprsRecursivelyOnce (e : Expr) (replacements : List (Expr × Expr)) (skipArgIndex : Option Nat := none) : Expr :=
+    If skipArgIndices is non-empty and the top-level expression is an application,
+    skips replacement in the arguments at those indices. -/
+partial def replaceExprsRecursivelyOnce (e : Expr) (replacements : List (Expr × Expr)) (skipArgIndices : List Nat := []) : Expr :=
   let (result, _) := StateT.run (aux e true) replacements
   result
 where
@@ -300,10 +300,8 @@ where
         if isTopLevel then
           -- Handle top-level application with potential argument skipping
           let (fn, args) := expr.getAppFnArgs
-          let args' ← args.toList.mapIdxM (fun i arg =>
-            match skipArgIndex with
-            | some skipIdx => if i == skipIdx then return arg else aux arg false
-            | none => aux arg false)
+          let args' ← args.toList.mapIdxM (fun (i : Nat) arg =>
+            if i ∈ skipArgIndices then return arg else aux arg false)
           return mkAppN (mkConst fn []) args'.toArray
         else do
           let f' ← aux f false

--- a/Specimen/Utils.lean
+++ b/Specimen/Utils.lean
@@ -3,6 +3,13 @@ import Lean
 
 open Lean Meta LocalContext Std
 
+/-- Folds a non-empty list into a right-nested pair using a monadic pairing function.
+    Produces `pair a (pair b c)` for `[a, b, c]`. -/
+def tupleOfListM [Monad m] (onEmpty : m α) (pair : α → α → m α) : List α → m α
+  | [] => onEmpty
+  | [x] => pure x
+  | x :: xs => do let rest ← tupleOfListM onEmpty pair xs; pair x rest
+
 /-- A variable along with its fully elaborated type.
 Will likely be replaced by variables directly living in `Expr` at some point. -/
 structure TypedVar where

--- a/SpecimenTest.lean
+++ b/SpecimenTest.lean
@@ -41,6 +41,8 @@ import SpecimenTest.DeriveArbitrary.ParameterizedTypeTest
 import SpecimenTest.DeriveArbitrary.MutuallyRecursiveTypeTest
 import SpecimenTest.DeriveArbitrarySuchThat.DeriveSTLCGenerator
 import SpecimenTest.DeriveArbitrarySuchThat.NonLinearPatternsTest
+import SpecimenTest.DeriveArbitrarySuchThat.MultiOutputTest
+import SpecimenTest.DeriveArbitrarySuchThat.MultiOutputSTLCTest
 
 -- Tests for instances of `Enum` for simple types and for correctness of enumerator combinators
 import SpecimenTest.Enum.EnumInstancesTest

--- a/SpecimenTest/ArithCompiler/FancyCompilerBuggyTest.lean
+++ b/SpecimenTest/ArithCompiler/FancyCompilerBuggyTest.lean
@@ -45,7 +45,7 @@ def compiler_correct (stmt : Stmt) : Bool :=
 
 -- This is the big-step semantics from the inductive relation, derived to
 -- be an enumerator: It will "run" Eval on m and s and produce m2.
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun m s => ∃ m2, Eval m s m2)
 
 -- This is our correctness statement from above, but using the enumerator

--- a/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
+++ b/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
@@ -89,231 +89,231 @@ deriving instance DecidableEq for PathSet
 -- Checker & Generator for `RecordExpr` relation
 --------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ce => Cedar.RecordExpr ce)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (ce : CedarExpr), Cedar.RecordExpr ce
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (Cedar.DefinedName · ·)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n r => Cedar.WfCedarType n r)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator fun n => ∃ (ns_1_1 : List EntityName), Cedar.DefinedName ns_1_1 n
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator fun r => ∃ ns_1, Cedar.WfCedarType ns_1 r
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator fun r => ∃ (ns_1 : List EntityName), Cedar.WfRecordType ns_1 r
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n r => Cedar.WfRecordType n r)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker fun ns TE t => Cedar.BindAttrType ns TE t
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator fun TE t_1 => ∃ (ns : _), Cedar.BindAttrType ns TE t_1
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun p t_1_1 => ∃ E, Cedar.LookupEntityAttr E p t_1_1)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n t_1 => ∃ (ets : _), Cedar.GetEntityAttr ets n t_1)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ce => Cedar.SetExpr ce)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (ce : CedarExpr), Cedar.SetExpr ce
 
 set_option maxHeartbeats 2000000
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ce => Cedar.SetEntityValues ce)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (ce : CedarExpr), Cedar.SetEntityValues ce
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun uid_1 p rs c l_1_1 => ∃ (rs_1_1 : _), Cedar.ActionToRequestTypes uid_1 p rs c l_1_1 rs_1_1)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns n => Cedar.DefinedName ns n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (n : EntityName), Cedar.DefinedName ns n)
 
 --------------------------------------------------
 -- Checker & Generator for `DefinedNames` relation
 --------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns ns0 => Cedar.DefinedNames ns ns0)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (ns0 : List EntityName), Cedar.DefinedNames ns ns0)
 
 --------------------------------------------------
 -- Checker & Generator for well-formed Cedar types
 --------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns ct => Cedar.WfCedarType ns ct)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (ct : CedarType), Cedar.WfCedarType ns ct)
 
 ----------------------------------------------------
 -- Checker & Generator for well-formed record types
 ----------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns rt => Cedar.WfRecordType ns rt)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (rt : CedarType), Cedar.WfRecordType ns rt)
 
 ----------------------------------------------------
 -- Checker & Generator for well-formed attributes
 ----------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns attrs => Cedar.WfAttrs ns attrs)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (attrs : List (String × Bool × CedarType)), Cedar.WfAttrs ns attrs)
 
 ---------------------------------------------------------------------
 -- Checker & Generator for well-formed `EntitySchemaEntry`(ies)
 ---------------------------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns et => Cedar.WfET ns et)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (et : EntitySchemaEntry), Cedar.WfET ns et)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns ns0 ets => Cedar.WfETS ns ns0 ets)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns ns0 => ∃ (ets : List (EntityName × EntitySchemaEntry)), Cedar.WfETS ns ns0 ets)
 
 ---------------------------------------------------------------------
 -- Checker & Generator for well-formed `ActionSchemaEntry`(ies)
 ---------------------------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns act => Cedar.WfACT ns act)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (act : EntityUID × ActionSchemaEntry), Cedar.WfACT ns act)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns act => Cedar.WfACTS ns act)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (act : List (EntityUID × ActionSchemaEntry)), Cedar.WfACTS ns act)
 
 ------------------------------------------------------------
 -- Checker & Generator for well-formed schemas
 ------------------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns s => Cedar.WfSchema ns s)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns => ∃ (s : Schema), Cedar.WfSchema ns s)
 
 ------------------------------------------------------------
 -- Checker & Generator for defined entities
 ------------------------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ets n => Cedar.DefinedEntity ets n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ets => ∃ (n : EntityName), Cedar.DefinedEntity ets n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ets n => Cedar.DefinedEntities ets n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ets => ∃ (n : List EntityName), Cedar.DefinedEntities ets n)
 
 ---------------------------------------------
 -- Schema: LookupEntityAttr / GetEntityAttr
 ---------------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun l fnb t => Cedar.LookupEntityAttr l fnb t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun l t => ∃ (fnb : (String × Bool)), Cedar.LookupEntityAttr l fnb t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker fun ets nfn t => GetEntityAttr ets nfn t
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ets t => ∃ (nfn : (EntityName × String × Bool)), Cedar.GetEntityAttr ets nfn t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun c t => Cedar.ReqContextToCedarType c t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun c => ∃ (t : CedarType), Cedar.ReqContextToCedarType c t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun e n ns l rs => ∃ (reqs : List RequestType), Cedar.ActionToRequestTypes e n ns l rs reqs)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun e ae ls => ∃ (reqs : List RequestType), Cedar.ActionSchemaEntryToRequestTypes e ae ls reqs)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun acts ls => ∃ (reqs : List RequestType), Cedar.ActionSchemaToRequestTypes acts ls reqs)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun s l => ∃ (es : List Environment), Cedar.SchemaToEnvironments s l es)
 
 ---------------------------------------
 -- Checker & Generator for RecordTypes
 ---------------------------------------
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ct => Cedar.RecordType ct)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (ct : CedarType), Cedar.RecordType ct
 
 --------------------
 -- Subtyping & Typing
 --------------------
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun t1 t2 => Cedar.SubType t1 t2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun t2 => ∃ (t1 : CedarType), Cedar.SubType t1 t2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun v t => ∃ (p : Prim), Cedar.HasTypePrim v p t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun v x => ∃ (t : CedarType), Cedar.HasTypeVar v x t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun v t => ∃ (x : Var), Cedar.HasTypeVar v x t)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun ns tef t => Cedar.BindAttrType ns tef t)
 
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ns t => ∃ (tef : (CedarType × String × Bool)), Cedar.BindAttrType ns tef t)
 
 #guard_msgs(drop info) in
@@ -323,5 +323,5 @@ derive_generator (fun ns p => ∃ (T : _), Cedar.BindAttrType ns p T)
 -- Generator for well-typed Cedar expressions
 ------------------------------------------------------------
 -- set_option trace.plausible.deriving.results true
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #time derive_generator (fun a v t => ∃ (ex : (CedarExpr × PathSet)), Cedar.HasType a v ex t)

--- a/SpecimenTest/DeriveArbitrary/StructureParameterTest.lean
+++ b/SpecimenTest/DeriveArbitrary/StructureParameterTest.lean
@@ -22,10 +22,10 @@ instance [Repr T.Meta] [Repr T.IDMeta] : Repr (Bar T) where
 
 deriving instance Arbitrary for Bar
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Arbitrary (Bar ⟨Bool, Nat⟩)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval Arbitrary.runArbitrary (α := Bar ⟨Bool, Nat⟩) 5
 
 /-! ## Mixed: normal type parameter + structure parameter -/
@@ -44,10 +44,10 @@ instance [Repr α] [Repr C.Tag] : Repr (Mixed α C) where
 
 deriving instance Arbitrary for Mixed
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Arbitrary (Mixed Nat ⟨Bool⟩)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval Arbitrary.runArbitrary (α := Mixed Nat ⟨Bool⟩) 5
 
 /-! ## Rejection of structures with non-Type fields -/
@@ -71,10 +71,10 @@ instance [Repr T.base.Meta] [Repr T.base.IDMeta] [Repr T.Extra] : Repr (Nested T
 
 deriving instance Arbitrary for Nested
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Arbitrary (Nested ⟨⟨Bool, Nat⟩, String⟩)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval Arbitrary.runArbitrary (α := Nested ⟨⟨Bool, Nat⟩, String⟩) 5
 
 /-! ## Rejection of structures with non-Type fields -/

--- a/SpecimenTest/DeriveArbitrarySuchThat/DependentArgs.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DependentArgs.lean
@@ -31,13 +31,13 @@ derive_generator (fun α l => ∃ n, @HasDep α l n)
 inductive HasClassDep {α : Type} [h : DecidableEq α] : Nat → Prop where
 | foo (a b : α) : a = b → HasClassDep 0
 
-#guard_msgs(drop info, error) in
+#guard_msgs(drop info, drop warning) in
 derive_generator (fun α inst => ∃ n, @HasClassDep α inst n)
 
-#guard_msgs(error, drop warning, drop info) in
+#guard_msgs(drop info, drop warning) in
 derive_checker fun α inst n => @HasClassDep α inst n
 
-#guard_msgs(drop info, error) in
+#guard_msgs(drop info, drop warning) in
 derive_enumerator (fun α inst => ∃ n, @HasClassDep α inst n)
 
 def f : Nat → Nat := fun _ => 0

--- a/SpecimenTest/DeriveArbitrarySuchThat/DependentArgs.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DependentArgs.lean
@@ -31,13 +31,13 @@ derive_generator (fun α l => ∃ n, @HasDep α l n)
 inductive HasClassDep {α : Type} [h : DecidableEq α] : Nat → Prop where
 | foo (a b : α) : a = b → HasClassDep 0
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun α inst => ∃ n, @HasClassDep α inst n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker fun α inst n => @HasClassDep α inst n
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun α inst => ∃ n, @HasClassDep α inst n)
 
 def f : Nat → Nat := fun _ => 0

--- a/SpecimenTest/DeriveArbitrarySuchThat/DependentOutputTypeTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DependentOutputTypeTest.lean
@@ -25,9 +25,9 @@ inductive Wraps (α : Type) : α → Box α → Prop where
 
 set_option maxHeartbeats 400000
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun (α : Type) (_inst : DecidableEq α) (x : α) =>
   ∃ (b : Box α), @Wraps α x b)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth ArbitrarySizedSuchThat (Box Nat) (fun b => Wraps Nat 42 b)

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
@@ -13,12 +13,12 @@ open ArbitrarySizedSuchThat
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun lo hi => ∃ (x : Nat), Between lo x hi)
 
 deriving instance Arbitrary for BinaryTree
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
 
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveBalancedTreeGenerator.lean
@@ -20,5 +20,5 @@ inductive balancedTree : Nat → BinaryTree → Prop where
     balancedTree n l → balancedTree n r →
     balancedTree (.succ n) (BinaryTree.Node x l r)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n => ∃ (t : BinaryTree), balancedTree n t)

--- a/SpecimenTest/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
@@ -4,8 +4,8 @@ import SpecimenTest.CommonDefinitions.Permutation
 
 /-! Snapshot test: derived constrained generator for list permutations. -/
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun l' => ∃ (l : List Nat), Permutation l l')
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun l' => ∃ (l : List Nat), Permutation l' l)

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
@@ -61,7 +61,7 @@ def r0 : RegExp :=
 
 -- Generator for strings that match the regexp `re`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun re => ∃ (s : List Nat), ExpMatch s re)
 
 -- To sample from this generator and print out 10 successful examples using the `Repr`

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
@@ -13,16 +13,16 @@ open ArbitrarySizedSuchThat
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun Γ τ => ∃ (x : Nat), lookup Γ x τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun G e => ∃ (t : type), typing G e t)
 -- set_option trace.plausible.deriving.results true
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #time derive_generator (fun G t => ∃ (e : term), typing G e t)
 
 -- To sample from this generator and print out 10 successful examples using the `Repr`
@@ -34,7 +34,7 @@ namespace STLCGeneratorTest
 inductive Foo {α} [h : Inhabited α] : α → Prop where
 | foo c : Foo c
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator fun α [Inhabited α] => ∃ c : α, Foo c
 
 end STLCGeneratorTest

--- a/SpecimenTest/DeriveArbitrarySuchThat/FunctionCallsTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/FunctionCallsTest.lean
@@ -31,11 +31,11 @@ will match one of the preceding alternatives
 #guard_msgs(error, drop info) in
 derive_generator (fun n => ∃ (m : Nat), square_of'' m n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n => ∃ (m : Nat), square_of' m n)
 
 /--error: exprToConstructorExpr can only handle free variables, constants, and applications. Attempted to convert: Unit → Nat-/
-#guard_msgs(error, drop warning) in
+#guard_msgs(error) in
 derive_generator (fun n => ∃ (m : Nat), square_of''' m n)
 
 example : Function.Injective (fun a => a * 1) := fun _ _ h => by exact Nat.add_left_cancel h

--- a/SpecimenTest/DeriveArbitrarySuchThat/InstanceParameterTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/InstanceParameterTest.lean
@@ -17,11 +17,11 @@ inductive MyRel {α : Type} [DecidableEq α] : α → Nat → Prop where
 
 set_option maxHeartbeats 400000
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun (α : Type) (inst : DecidableEq α) (x : α) =>
   ∃ n, @MyRel α inst x n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth ArbitrarySizedSuchThat Nat (fun n => @MyRel Nat instDecidableEqNat 42 n)
 
 /-! ## Eta-expanded instance lambdas in constructor arguments
@@ -36,9 +36,9 @@ a typeclass instance and skip it. -/
 inductive PairRel {α : Type} [DecidableEq α] : α → (α × α) → Prop where
   | mk : PairRel x (x, x)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun (α : Type) (inst : DecidableEq α) (x : α) =>
   ∃ (p : α × α), @PairRel α inst x p)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth @ArbitrarySizedSuchThat (Nat × Nat) (fun p => @PairRel Nat instDecidableEqNat 42 p)

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
@@ -13,34 +13,36 @@ open Plausible
 set_option guard_msgs.diff true
 
 -- Generate both a term and its type given a context Γ (standard mode)
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun Γ => ∃ (e : term) (τ : type), typing Γ e τ)
 
 /-! ## Multi-output mode for non-recursive relations -/
 
 -- Multi-output lookup: all three as outputs
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator_multi (∃ (Γ : List type) (x : Nat) (τ : type), lookup Γ x τ)
 
 -- Multi-output lookup: τ as input, Γ and x as outputs
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator_multi (fun τ => ∃ (Γ : List type) (x : _), lookup Γ x τ)
 
 -- Verify the instance type
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat (term × type) (fun (e, τ) => typing [] e τ))
 
 -- Sample: generate a well-typed closed term along with its type
+#guard_msgs(drop info) in
 #eval do
   let sample ← Gen.run
     (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : term × type) => typing [] p.1 p.2) 5) 10
   return repr sample
 
 -- Generate both an index and a type from a lookup judgment given a context
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun Γ => ∃ (x : Nat) (τ : type), lookup Γ x τ)
 
 -- Sample: generate a valid (index, type) pair for a non-empty context
+#guard_msgs(drop info) in
 #eval do
   let ctx : List type := [.Nat, .Fun .Nat .Nat, .Nat]
   let sample ← Gen.run

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
@@ -1,0 +1,48 @@
+import Plausible.Gen
+import Specimen.ArbitrarySizedSuchThat
+import Specimen.DeriveConstrainedProducer
+import SpecimenTest.DeriveArbitrary.DeriveSTLCTermTypeGenerators
+import SpecimenTest.DeriveDecOpt.DeriveSTLCChecker
+import SpecimenTest.DeriveArbitrarySuchThat.DeriveSTLCGenerator
+
+/-! Test: multi-output constrained generation for STLC.
+    Generate both a well-typed term AND its type given a context. -/
+
+open Plausible
+
+set_option guard_msgs.diff true
+
+-- Generate both a term and its type given a context Γ (standard mode)
+#guard_msgs(drop info, drop warning) in
+derive_generator (fun Γ => ∃ (e : term) (τ : type), typing Γ e τ)
+
+/-! ## Multi-output mode for non-recursive relations -/
+
+-- Multi-output lookup: all three as outputs
+#guard_msgs(drop info, drop warning) in
+derive_generator_multi (∃ (Γ : List type) (x : Nat) (τ : type), lookup Γ x τ)
+
+-- Multi-output lookup: τ as input, Γ and x as outputs
+#guard_msgs(drop info, drop warning) in
+derive_generator_multi (fun τ => ∃ (Γ : List type) (x : _), lookup Γ x τ)
+
+-- Verify the instance type
+#guard_msgs(drop info, drop warning) in
+#check (inferInstance : ArbitrarySizedSuchThat (term × type) (fun (e, τ) => typing [] e τ))
+
+-- Sample: generate a well-typed closed term along with its type
+#eval do
+  let sample ← Gen.run
+    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : term × type) => typing [] p.1 p.2) 5) 10
+  return repr sample
+
+-- Generate both an index and a type from a lookup judgment given a context
+#guard_msgs(drop info, drop warning) in
+derive_generator (fun Γ => ∃ (x : Nat) (τ : type), lookup Γ x τ)
+
+-- Sample: generate a valid (index, type) pair for a non-empty context
+#eval do
+  let ctx : List type := [.Nat, .Fun .Nat .Nat, .Nat]
+  let sample ← Gen.run
+    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : Nat × type) => lookup ctx p.1 p.2) 5) 10
+  return repr sample

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
@@ -19,14 +19,14 @@ inductive Split : Nat → Nat → Nat → Prop where
 deriving instance Arbitrary for Nat
 
 -- Multiple outputs: generate both a and b such that Split n a b holds (for a given n)
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n => ∃ a b, Split n a b)
 
 -- Verify the instance was created for the product type
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat (Nat × Nat) (fun (a, b) => Split 5 a b))
 
 set_option trace.plausible.deriving.results true
 
-#guard_msgs(drop warning) in
+#guard_msgs(drop info) in
 derive_generator (∃ a n b, Split n a b)

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
@@ -1,0 +1,32 @@
+import Plausible.Gen
+import Specimen.ArbitrarySizedSuchThat
+import Specimen.DeriveConstrainedProducer
+import Specimen.DeriveArbitrary
+import Plausible.Arbitrary
+
+/-! Test: derive constrained generators with multiple existential output variables. -/
+
+open Plausible
+
+set_option guard_msgs.diff true
+
+-- A simple non-recursive relation where two outputs can be determined from one input
+inductive Split : Nat → Nat → Nat → Prop where
+  | zero : Split 0 0 0
+  | left : Split n.succ n 1
+  | right : Split n.succ 1 n
+
+deriving instance Arbitrary for Nat
+
+-- Multiple outputs: generate both a and b such that Split n a b holds (for a given n)
+#guard_msgs(drop info, drop warning) in
+derive_generator (fun n => ∃ a b, Split n a b)
+
+-- Verify the instance was created for the product type
+#guard_msgs(drop info, drop warning) in
+#check (inferInstance : ArbitrarySizedSuchThat (Nat × Nat) (fun (a, b) => Split 5 a b))
+
+set_option trace.plausible.deriving.results true
+
+#guard_msgs(drop warning) in
+derive_generator (∃ a n b, Split n a b)

--- a/SpecimenTest/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MutuallyRecursiveRelationsTest.lean
@@ -28,8 +28,8 @@ end
 instance : ArbitrarySizedSuchThat Nat (fun n => Odd n) where
   arbitrarySizedST (_ : Nat) := return 1
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (n : Nat), Even n
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator ∃ (n : Nat), Odd n

--- a/SpecimenTest/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/NonLinearPatternsTest.lean
@@ -15,7 +15,7 @@ set_option guard_msgs.diff true
 inductive GoodTree : Nat → Nat → BinaryTree → Prop where
   | GoodLeaf : ∀ n, GoodTree n n .Leaf
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun in1 in2 => ∃ (t : BinaryTree), GoodTree in1 in2 t)
 
 
@@ -25,5 +25,5 @@ derive_generator (fun in1 in2 => ∃ (t : BinaryTree), GoodTree in1 in2 t)
 inductive SameHead : List Nat → List Nat → Prop where
 | HeadMatch : ∀ x xs ys, SameHead (x::xs) (x::ys)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ys => ∃ (xs : List Nat), SameHead xs ys)

--- a/SpecimenTest/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/SimultaneousMatchingTests.lean
@@ -14,21 +14,21 @@ open ArbitrarySizedSuchThat
 set_option guard_msgs.diff true
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x => ∃ (l : List Nat), InList x l)
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun a => ∃ (l: List Nat), MinOk l a)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n l' => ∃ (l : List Nat), MinEx n l l')
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x l' => ∃ (l : List Nat), MinEx3 x l l')
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x l => ∃ (l' : List Nat), MinEx2 x l l')
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x l' => ∃ (l : List Nat), MinEx2 x l l')

--- a/SpecimenTest/DeriveArbitrarySuchThat/WithUnfolds.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/WithUnfolds.lean
@@ -45,14 +45,14 @@ Hint: Type class instance resolution failures can be inspected with the `set_opt
 #check ArbitrarySizedSuchThat.arbitrarySizedST (fun (x : Nat) => Eq (OfNat.ofNat 0) x)
 
 -- These succeed: NatFoo.ty unfolds to Nat via whnf
-#guard_msgs(error, drop info, drop warning) in
+#guard_msgs(error, drop info) in
 derive_generator ∃ (n : Nat), TypeBoxPred n
 
-#guard_msgs(error, drop info, drop warning) in
+#guard_msgs(error, drop info) in
 derive_generator ∃ (n : _), TypeBoxPredS n
 
 -- This fails at elaboration: SomeFoo is opaque so SomeFoo.ty cannot be resolved,
 -- and DecOpt (x = x) has no instance for opaque types. Errors are dropped since
 -- they are not user-friendly (see open-issues.md).
-#guard_msgs(drop error, drop info, drop warning) in
+#guard_msgs(drop error, drop info) in
 derive_generator ∃ (n : Nat), TypeBoxPredOpaque n

--- a/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
@@ -10,8 +10,8 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun lo x hi => Between lo x hi)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun lo hi t => BST lo hi t)

--- a/SpecimenTest/DeriveDecOpt/DeriveBalancedTreeChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveBalancedTreeChecker.lean
@@ -9,5 +9,5 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n t => balancedTree n t)

--- a/SpecimenTest/DeriveDecOpt/DerivePermutationChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DerivePermutationChecker.lean
@@ -6,7 +6,7 @@ import SpecimenTest.DeriveEnumSuchThat.DerivePermutationEnumerator
 /-! Snapshot test: derived `DecOpt` checker for the `Permutation` relation. -/
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun l l' => Permutation l l')
 
 

--- a/SpecimenTest/DeriveDecOpt/DeriveRegExpMatchChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveRegExpMatchChecker.lean
@@ -18,5 +18,5 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun s r0 => ExpMatch s r0)

--- a/SpecimenTest/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -11,5 +11,5 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun Γ e τ => typing Γ e τ)

--- a/SpecimenTest/DeriveDecOpt/ExistentialVariablesTest.lean
+++ b/SpecimenTest/DeriveDecOpt/ExistentialVariablesTest.lean
@@ -30,16 +30,16 @@ inductive NatChain (a b : Nat) : Prop where
     (LessThanEq y b) →
     NatChain a b
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun x => ∃ (a : Nat), LessThanEq a x)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun x => ∃ (y : Nat), LessThanEq x y)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n m => LessThanEq n m)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun a b => NatChain a b)
 
 -- Regression test: argument names that collide with internal reserved names
@@ -52,7 +52,7 @@ inductive SizedLe : Nat → Nat → Prop where
   | Refl : ∀ n, SizedLe n n
   | Succ : ∀ size' n, SizedLe size' n → SizedLe size' (Nat.succ n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun size' n => SizedLe size' n)
 
 /-- Like `LessThanEq` but with an argument deliberately named `aux_dec`
@@ -61,8 +61,8 @@ inductive AuxDecLe : Nat → Nat → Prop where
   | Refl : ∀ n, AuxDecLe n n
   | Succ : ∀ aux_dec n, AuxDecLe aux_dec n → AuxDecLe aux_dec (Nat.succ n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun aux_dec n => AuxDecLe aux_dec n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun size' => ∃ n, SizedLe size' n)

--- a/SpecimenTest/DeriveDecOpt/FunctionCallsTest.lean
+++ b/SpecimenTest/DeriveDecOpt/FunctionCallsTest.lean
@@ -10,5 +10,5 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n m => square_of n m)

--- a/SpecimenTest/DeriveDecOpt/NonLinearPatternsTest.lean
+++ b/SpecimenTest/DeriveDecOpt/NonLinearPatternsTest.lean
@@ -9,5 +9,5 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun in1 in2 t => GoodTree in1 in2 t)

--- a/SpecimenTest/DeriveDecOpt/SimultaneousMatchingTests.lean
+++ b/SpecimenTest/DeriveDecOpt/SimultaneousMatchingTests.lean
@@ -9,11 +9,11 @@ open DecOpt
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun x l => InList x l)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun l a => MinOk l a)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun n l a => MinEx n l a)

--- a/SpecimenTest/DeriveEnum/BitVecStructureTest.lean
+++ b/SpecimenTest/DeriveEnum/BitVecStructureTest.lean
@@ -11,17 +11,17 @@ deriving instance Enum for DummyInductive
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized DummyInductive
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum DummyInductive
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum DummyInductive
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/DeriveNKIBinopEnumerator.lean
+++ b/SpecimenTest/DeriveEnum/DeriveNKIBinopEnumerator.lean
@@ -11,17 +11,17 @@ deriving instance Enum for BinOp
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized BinOp
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum BinOp
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum BinOp
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/DeriveNKIValueEnumerator.lean
+++ b/SpecimenTest/DeriveEnum/DeriveNKIValueEnumerator.lean
@@ -11,17 +11,17 @@ set_option guard_msgs.diff true
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized Value
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum Value
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum Value
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/DeriveRegExpEnumerator.lean
+++ b/SpecimenTest/DeriveEnum/DeriveRegExpEnumerator.lean
@@ -11,17 +11,17 @@ deriving instance Enum for RegExp
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized RegExp
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum RegExp
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum RegExp
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
+++ b/SpecimenTest/DeriveEnum/DeriveSTLCTermTypeEnumerators.lean
@@ -13,26 +13,26 @@ deriving instance Enum for type, term
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 -- for both `type` & `term`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized type
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized term
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum type
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum term
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum type
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum term
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/DeriveTreeEnumerator.lean
+++ b/SpecimenTest/DeriveEnum/DeriveTreeEnumerator.lean
@@ -12,17 +12,17 @@ deriving instance Enum for BinaryTree
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized BinaryTree
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum BinaryTree
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum BinaryTree
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnum/NestedAndMutualRecursionTest.lean
+++ b/SpecimenTest/DeriveEnum/NestedAndMutualRecursionTest.lean
@@ -15,10 +15,10 @@ inductive NestedTree where
 
 deriving instance Enum for NestedTree
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized NestedTree
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum NestedTree
 
 /-- info: [NestedTree.node 0 [], NestedTree.leaf] -/
@@ -40,16 +40,16 @@ end
 
 deriving instance Enum for MutEven, MutOdd
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized MutEven
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized MutOdd
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum MutEven
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum MutOdd
 
 -- Verify the enumerators produce non-empty output.
@@ -57,8 +57,8 @@ deriving instance Enum for MutEven, MutOdd
 -- DeriveArbitrary) does not decrement fuel for cross-type calls, so the
 -- enumerator exhaustively produces all reachable chains. We drop the output
 -- and just check that evaluation succeeds.
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval (runEnum (α := MutEven) 0)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval (runEnum (α := MutOdd) 0)

--- a/SpecimenTest/DeriveEnum/StructureParameterTest.lean
+++ b/SpecimenTest/DeriveEnum/StructureParameterTest.lean
@@ -20,7 +20,7 @@ instance [Repr T.Meta] [Repr T.IDMeta] : Repr (Bar T) where
 
 deriving instance Enum for Bar
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized (Bar ⟨Bool, Nat⟩)
 
 /-- info: [Bar.mk true 0, Bar.mk false 0] -/
@@ -43,10 +43,10 @@ instance [Repr α] [Repr C.Tag] : Repr (Mixed α C) where
 
 deriving instance Enum for Mixed
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum (Mixed Bool ⟨Nat⟩)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval (runEnum (α := Mixed Bool ⟨Nat⟩) 0)
 
 /-! ## Nested structure parameter -/
@@ -68,10 +68,10 @@ instance [Repr T.base.Meta] [Repr T.base.IDMeta] [Repr T.Extra] : Repr (Nested T
 
 deriving instance Enum for Nested
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum (Nested ⟨⟨Bool, Nat⟩, String⟩)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #eval (runEnum (α := Nested ⟨⟨Bool, Nat⟩, String⟩) 0)
 
 /-! ## Rejection of structures with non-Type fields -/

--- a/SpecimenTest/DeriveEnum/StructureTest.lean
+++ b/SpecimenTest/DeriveEnum/StructureTest.lean
@@ -11,17 +11,17 @@ deriving instance Enum for Foo
 
 -- Test that we can successfully synthesize instances of `Arbitrary` & `ArbitrarySized`
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth EnumSized Foo
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 #synth Enum Foo
 
 -- We test the command elaborator frontend in a separate namespace to
 -- avoid overlapping typeclass instances for the same type
 namespace CommandElaboratorTest
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enum Foo
 
 end CommandElaboratorTest

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
@@ -8,8 +8,8 @@ import SpecimenTest.DeriveArbitrarySuchThat.DeriveBSTGenerator
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun lo hi => ∃ (x : Nat), Between lo x hi)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
@@ -8,5 +8,5 @@ import SpecimenTest.DeriveArbitrarySuchThat.DeriveBalancedTreeGenerator
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun n => ∃ (t : BinaryTree), balancedTree n t)

--- a/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -5,8 +5,8 @@ import SpecimenTest.CommonDefinitions.Permutation
 /-! Snapshot test: derived constrained enumerator for the `Permutation` relation. -/
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun l' => ∃ (l : List Nat), Permutation l l')
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun l' => ∃ (l : List Nat), Permutation l' l)

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
@@ -8,7 +8,7 @@ import SpecimenTest.DeriveArbitrarySuchThat.DeriveRegExpMatchGenerator
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun r0 => ∃ (s : List Nat), ExpMatch s r0)
 
 -- To sample from this enumerator, we can run the following:

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
@@ -10,13 +10,13 @@ import SpecimenTest.DeriveEnum.DeriveSTLCTermTypeEnumerators
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun Γ τ => ∃ (x : Nat), lookup Γ x τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun Γ x τ => lookup Γ x τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
 
@@ -130,11 +130,11 @@ end
 instance : DecOpt (typing Γ_1 e_1 τ_1) where
   decOpt := checkTyping Γ_1 e_1 τ_1
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun Γ x => ∃ (τ : type), lookup Γ x τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun Γ e => ∃ (τ : type), typing Γ e τ)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun Γ τ => ∃ (e : term), typing Γ e τ)

--- a/SpecimenTest/DeriveEnumSuchThat/NonLinearPatternsTest.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/NonLinearPatternsTest.lean
@@ -11,5 +11,5 @@ import SpecimenTest.DeriveArbitrarySuchThat.NonLinearPatternsTest
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun in1 in2 => ∃ (t : BinaryTree), GoodTree in1 in2 t)

--- a/SpecimenTest/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/SimultaneousMatchingTests.lean
@@ -11,11 +11,11 @@ import SpecimenTest.CommonDefinitions.ListRelations
 
 set_option guard_msgs.diff true
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun x => ∃ (l : List Nat), InList x l)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun a => ∃ (l: List Nat), MinOk l a)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator (fun n a => ∃ (l: List Nat), MinEx n l a)

--- a/SpecimenTest/Enum/EnumeratorSizeTest.lean
+++ b/SpecimenTest/Enum/EnumeratorSizeTest.lean
@@ -22,9 +22,9 @@ combining them into the top level enumerator for an inductive family.
 
 -/
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator ∃ (n : _), onetrue n
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_enumerator ∃ (n : _), onetrue' n
 
 /--

--- a/SpecimenTest/KeyValueStoreExample/TestKeyValueStoreCheckerGenerators.lean
+++ b/SpecimenTest/KeyValueStoreExample/TestKeyValueStoreCheckerGenerators.lean
@@ -29,52 +29,52 @@ instance instKeyValueStoreArbitraryString : Arbitrary String where
 ---------------------------------------------------------------------------------------------------------------------------------------
 
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun k s2 => ∃ (s1 : List (String × String)), KeyValueStore.RemoveKV k s1 s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun ka s1a => ∃ (s2a : List (String × String)), KeyValueStore.RemoveKV ka s1a s2a)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun k v s2 => ∃ (s1 : List (String × String)), KeyValueStore.AddKV k v s1 s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun k v s1 => ∃ (s2 : List (String × String)), KeyValueStore.AddKV k v s1 s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun k x_1 s2 => ∃ (v : String), KeyValueStore.AddKV k v x_1 s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun s kv => KeyValueStore.LookupKV s kv)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun kv => ∃ (s1 : List (String × String)), KeyValueStore.LookupKV s1 kv)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun k2 v s_1 s2 => KeyValueStore.AddKV k2 v s_1 s2)
 
 #guard_msgs(drop info) in
 derive_checker (fun k s s2 => RemoveKV k s s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x => ∃ (s : List (String × String)), KeyValueStore.EvalStateApiCall s x)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun s => ∃ (kv : StateResult × String × Nat × String), KeyValueStore.LookupKV s kv)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun s => ∃ (nb : Nat × List (String × String)), KeyValueStore.GetBucket s nb)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun v x_1 s2 => ∃ (k : _), KeyValueStore.AddKV k v x_1 s2)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun x => ∃ (foo : StateAPICall × StateResult × List (String × String)), KeyValueStore.EvalStateApiCall x foo)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun s => ∃ (crns : APICall × Result × (Nat × List (Nat × List (String × String)))), KeyValueStore.EvalApiCall s crns)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun s => ∃ (o : List (APICall × Result) × (Nat × List (Nat × List (String × String)))), KeyValueStore.EvalApiCalls s o)
 
 

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -86,10 +86,10 @@ inductive MemNat : List Nat → Nat → Prop where
 | here  : ∀ n xs, MemNat (n :: xs) n
 | there : ∀ n m xs, n ≠ m → MemNat xs n → MemNat (m :: xs) n
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_checker (fun xs n => MemNat xs n)
 
-#guard_msgs(drop info, drop warning) in
+#guard_msgs(drop info) in
 derive_generator (fun n => ∃ xs, MemNat xs n)
 
 /--


### PR DESCRIPTION
## Summary

Adds support for generating multiple existentially-quantified output variables. Previously, `derive_generator` and `derive_enumerator` could only produce a single output variable. Now specs like `∃ a b, R n a b` are supported, with the derived instance producing a right-nested `Prod` type (`a × b`).

### Changes

- **`DeriveConstrainedProducer.lean`**: Handle multi-output indices throughout the derivation pipeline — schedule construction, compilation, and instance emission all support `outputIndices` with more than one position
- **`MExp.lean`**: Return tuples via `Prod.mk` when multiple outputs are produced; bind results using right-nested tuple patterns
- **`MakeConstrainedProducerInstance.lean`**: `ArbitrarySizedSuchThat`/`EnumSizedSuchThat` instances use product types for multi-output; emit `fun (a, (b, c)) => @R ...` lambda patterns
- **`DeriveSchedules.lean`**: Schedule derivation respects multi-output — output positions are tracked as a `List Nat` rather than a single index
- **`GeneratorCombinators.lean`**: Minor combinator adjustments for product-typed results

### Limitations

Multi-output for recursive relations (e.g., STLC typing where "all outputs" and "some fixed" splits are mutually recursive) requires mutual recursion support, addressed in the next PR.

## Test plan

- [x] `MultiOutputTest.lean` — derives generator for `Split` relation with 2 outputs from 1 input
- [x] `MultiOutputSTLCTest.lean` — multi-output generators for `lookup` and `typing` (non-recursive cases)
- [x] All 116 existing test jobs pass without regression

---
*PR 1 of 5 (stacked): **multi-output** → derive_mutual → auto-derive → fixes → HTML infoview*