### PR TITLE
Add derive_mutual command with fuel/size separation and true mutual recursion

### DIFF
--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -15,6 +15,12 @@ register_option specimen.multiOutput : Bool := {
   descr := "allow multi-output production steps in derived generators"
 }
 
+/-- Fuel for derived generators (termination device). High values are fine; only decrease for testing. -/
+register_option specimen.fuel : Nat := {
+  defValue := 10000
+  descr := "fuel (termination budget) for derived generators/enumerators/checkers"
+}
+
 /-- Global flag for enabling/disabling debug messages -/
 def globalDebugFlag : Bool := false
 

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -39,32 +39,40 @@ def getCheckerScheduleForInductiveConstructor (inductiveName : Name) (ctorName :
 def mkDecOptInstance (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax `term)
   (inductiveName : Name) (inductiveLevels : List Level) (args : TSyntaxArray `term) (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
 
-  -- Produce a fresh name for the `size` argument for the lambda
-  -- at the end of the checker function, as well as the `aux_dec` inner helper function
+  -- Produce fresh names for function parameters
   let freshSizeIdent := mkFreshAccessibleIdent topLevelLocalCtx `size
   let freshSize' := mkFreshAccessibleIdent topLevelLocalCtx `size'
+  let freshFuel' := mkFreshAccessibleIdent topLevelLocalCtx `fuel'
   let auxDecIdent := mkFreshAccessibleIdent topLevelLocalCtx `aux_dec
   let checkerType ← `($exceptTypeConstructor $genErrorType $boolIdent)
 
-  -- Create the cases for the pattern-match on the size argument
-  let mut caseExprs := #[]
+  -- Create the inner match on size
+  let mut sizeCaseExprs := #[]
   let zeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $checkerBacktrackFn $baseCheckers)
-  caseExprs := caseExprs.push zeroCase
-
+  sizeCaseExprs := sizeCaseExprs.push zeroCase
   let succCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshSize' => $checkerBacktrackFn $inductiveCheckers)
-  caseExprs := caseExprs.push succCase
+  sizeCaseExprs := sizeCaseExprs.push succCase
+  let sizeMatchExpr ← mkMatchExpr sizeIdent sizeCaseExprs
 
-  -- Create function arguments for the checker's `size` & `initSize` parameters
-  -- (former is the generator size, latter is the size argument with which to invoke other auxiliary generators/checkers)
+  -- Wrap with outer fuel match
+  let mut fuelCaseExprs := #[]
+  let fuelZeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $failFn $outOfFuelError)
+  fuelCaseExprs := fuelCaseExprs.push fuelZeroCase
+  let fuelSuccCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshFuel' => $sizeMatchExpr)
+  fuelCaseExprs := fuelCaseExprs.push fuelSuccCase
+  let matchExpr ← mkMatchExpr fuelIdent fuelCaseExprs
+
+  -- Create function arguments for the checker's `fuel`, `initSize` & `size` parameters
+  let fuelParam ← `(Term.letIdBinder| ($fuelIdent : $natIdent))
   let initSizeParam ← `(Term.letIdBinder| ($initSizeIdent : $natIdent))
   let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
-  let matchExpr ← mkMatchExpr sizeIdent caseExprs
 
   -- Add parameters for each argument to the inductive relation
   let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
 
   -- Inner params are for the inner `aux_dec` function
   let mut innerParams := #[]
+  innerParams := innerParams.push fuelParam
   innerParams := innerParams.push initSizeParam
   innerParams := innerParams.push sizeParam
 
@@ -88,11 +96,13 @@ def mkDecOptInstance (baseCheckers : TSyntax `term) (inductiveCheckers : TSyntax
   let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Enum, ``DecidableEq]
 
   -- Produces an instance of the `DecOpt` typeclass containing the definition for the derived generator
+  let fuelVal := Lean.Option.get (← getOptions) specimen.fuel
+  let fuelLit := Syntax.mkNumLit (toString fuelVal)
   `(instance $arbitraryTypeParamInstances:bracketedBinder* : $decOptTypeclass (@$(mkIdent inductiveName) $args*) where
       $unqualifiedDecOptFn:ident :=
         let rec $auxDecIdent:ident $innerParams* $arbitraryTypeParamInstances:bracketedBinder* : $checkerType :=
           $matchExpr
-        fun $freshSizeIdent => $auxDecIdent $freshSizeIdent $freshSizeIdent $outerParams*)
+        fun $freshSizeIdent => $auxDecIdent $fuelLit $freshSizeIdent $freshSizeIdent $outerParams*)
 
 
 def deriveScheduledChecker' (_args : Array Expr)
@@ -145,6 +155,7 @@ def deriveScheduledChecker' (_args : Array Expr)
       -- so they can be threaded through schedule derivation and MExp compilation.
       -- These must match the names used by `mkDecOptInstance`.
       let freshAuxDecName := localCtx.getUnusedName `aux_dec
+      let freshFuelPrimeName := localCtx.getUnusedName `fuel'
       let freshSizePrimeName := localCtx.getUnusedName `size'
 
       for ctorName in inductiveVal.ctors do
@@ -159,7 +170,7 @@ def deriveScheduledChecker' (_args : Array Expr)
           -- (where each term represents a typeclass instance)
           let (subChecker, instances) ← StateT.run (s := #[]) (do
             let recType := unifyState.outputTypes.headD (mkConst ``Bool)
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) recType freshSizePrimeName
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) recType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
             MExp.mexpToTSyntax mexp (deriveSort := .Checker))
 
           requiredInstances := requiredInstances ++ instances

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -266,7 +266,7 @@ def getScheduleSort (conclusion : HypothesisExpr)
 def linearizeAndFlatten
   (hypotheses : Array Expr) (conclusion : Expr) (outputIndices : List Nat) (localCtx : LocalContext) :
   UnifyM (Array Expr × Expr × List (Name × Expr) × LocalContext) := do
-  -- Find all sub-terms which are non-trivial function applications
+  -- Phase 1: flatten function calls into fresh unknowns with equality hypotheses
   let funcAppExprs ← collectUnmatchableProperSubterms conclusion
   trace[plausible.deriving.arbitrary] m!"Unmatchable exprs: {funcAppExprs} In conclusion: {conclusion}"
   withLCtx' localCtx do
@@ -301,7 +301,7 @@ def linearizeAndFlatten
     let functionsNewTypedVars := freshUnknownsAndTypes
     let functionsNewHyps := additionalHyps
 
-    -- Count variable occurrences to find nonlinear patterns
+    -- Phase 2: linearize repeated variables — each extra occurrence gets a fresh unknown + equality
     let varOccurrences := collectFVarOccurrences conclusion outputIndices
 
     trace[plausible.deriving.arbitrary] m!"varOccurences: {repr varOccurrences.toList} \n expr: {conclusion} \n outputIndices {outputIndices}"
@@ -530,7 +530,7 @@ def getScheduleForInductiveRelationConstructor
       trace[plausible.deriving.arbitrary] m!"Updated ForAll Vars: {repr updatedForAllVars}"
       trace[plausible.deriving.arbitrary] m!"Fixed Vars: {repr fixedVars}"
 
-      -- Compute all possible checker schedules for this constructor
+      -- Enumerate candidate schedules and select the best by score (checks < length < unconstrained)
       let multiOutput := Lean.Option.get (← getOptions) specimen.multiOutput
       let possibleSchedules := possibleSchedules
         (vars := updatedForAllVars)
@@ -699,6 +699,7 @@ def deriveConstrainedProducer
         | .Enumerator => `aux_enum
         | _ => `aux_dec)
 
+      -- For each constructor: derive schedule → compile to MExp → emit TSyntax term
       let mut requiredInstances := #[]
       for ctorName in inductiveVal.ctors do
         let scheduleOption ← (UnifyM.runInMetaM

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -782,6 +782,7 @@ def deriveConstrainedProducerParts
   TermElabM (TSyntax `term × TSyntax `term × Array Name × TSyntaxArray `term × Array Expr × LocalContext × Name × List Level × ProducerSort) := do
   let producerSort := convertDeriveSortToProducerSort deriveSort
   let inductiveName := constrainingInductive
+  -- Identify which argument positions are outputs (to be generated)
   let outputFVars := outputVars.map Expr.fvarId!
   let mut outputIdxs : Array Nat := #[]
   for i in [:constrArgs.size] do
@@ -790,6 +791,7 @@ def deriveConstrainedProducerParts
       outputIdxs := outputIdxs.push i
   if outputIdxs.isEmpty then
     throwError m!"cannot find output indices, try specifying the implicit arguments"
+  -- Extract argument names and types from the inductive's type signature
   let inductiveVal ← getConstInfoInduct inductiveName
   let inductiveTypeComponents ← getComponentsOfArrowType inductiveVal.type
   let argTypes := inductiveTypeComponents.pop
@@ -800,8 +802,10 @@ def deriveConstrainedProducerParts
         outputVars[outIdx]!.fvarId!.getUserName
       else throwError m!"{ident} is expected to be a variable.")
   let argNamesTypes := argNames.zip argTypes
+  -- Build the output product type (e.g., α × β for two outputs)
   let _outputType ← tupleOfListM (throwError "no output types")
     (fun t rest => mkAppM ``Prod #[t, rest]) outputTypes.toList
+  -- Freshen argument names to avoid capture, then derive schedules per constructor
   let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, localCtx) ←
     withLocalDeclsDND argNamesTypes (fun _ => do
       let mut localCtx ← getLCtx
@@ -823,6 +827,7 @@ def deriveConstrainedProducerParts
       let freshSize' := mkIdent freshSizePrimeName
       let freshRecFnName := recFnNameOverride.getD (localCtx.getUnusedName (match deriveSort with
         | .Generator => `aux_arb | .Enumerator => `aux_enum | _ => `aux_dec))
+      -- For each constructor: derive a schedule, compile to syntax
       for ctorName in inductiveVal.ctors do
         let scheduleOption ← (UnifyM.runInMetaM
           (getProducerScheduleForInductiveConstructor inductiveName ctorName outputNamesTypesIndices
@@ -996,24 +1001,8 @@ derive_mutual
 ```
 
 Each entry is either `generator`, `generator_multi`, `enumerator`, or `checker` followed by
-a term describing the constraint. Currently each entry is derived independently in sequence.
-
-### TODO for true mutual recursion:
-To support cases where the derived functions need to call each other (e.g., "all outputs"
-typing depends on "fixed type" typing and vice versa), the following changes are needed:
-
-1. **Scheduler**: Generalize `recCall : Name × List Nat` to
-   `recCalls : List (Name × List Nat × Name)` where the third component is the
-   aux function name of the sibling spec to call.
-
-2. **isRecCall**: Check against ALL sibling specs. When a hypothesis matches a sibling
-   spec (same inductive, compatible output positions), emit `Source.Rec siblingAuxName args`.
-
-3. **Code generation**: Emit a `mutual ... end` block of top-level `def`s instead of
-   `let rec` inside an instance. Each instance then references its corresponding `def`.
-
-4. **MExp → TSyntax**: `Source.Rec` already handles calling by name, so no changes needed
-   once the schedule correctly identifies mutual calls.
+a term describing the constraint. Entries in the same SCC are compiled into a shared
+`mutual` block with cross-calls rewritten to `Source.MutRec`.
 -/
 
 /-- Command for deriving multiple constrained generators in sequence,

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -687,6 +687,7 @@ def deriveConstrainedProducer
       let mut nonRecursiveProducers := #[]
       let mut recursiveProducers := #[]
 
+      let freshFuelPrimeName := localCtx.getUnusedName `fuel'
       let freshSizePrimeName := localCtx.getUnusedName `size'
       let freshSize' := mkIdent freshSizePrimeName
 
@@ -711,7 +712,7 @@ def deriveConstrainedProducer
           -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
           -- (where each term represents a typeclass instance)
           let (subProducer, instances) ← StateT.run (s := #[]) (do
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType freshSizePrimeName
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
             MExp.mexpToTSyntax mexp deriveSort)
 
           requiredInstances := requiredInstances ++ instances
@@ -768,6 +769,92 @@ def deriveConstrainedProducer
     outputTypes.toList
     producerSort
     localCtx
+
+/-- Like `deriveConstrainedProducer` but returns the components needed for assembly
+    into either a standalone instance or a mutual def block.
+    Returns: (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, inductiveName, inductiveLevels, producerSort) -/
+def deriveConstrainedProducerParts
+  (_args : Array Expr) (outputVars : Array Expr) (outputTypes : Array Expr)
+  (constrainingInductive : Name) (inductiveLevels : List Level)
+  (constrArgs : Array Expr) (deriveSort : DeriveSort)
+  (scheduleRewriter : List ScheduleStep → List ScheduleStep := id)
+  (recFnNameOverride : Option Name := none) :
+  TermElabM (TSyntax `term × TSyntax `term × Array Name × TSyntaxArray `term × Array Expr × LocalContext × Name × List Level × ProducerSort) := do
+  let producerSort := convertDeriveSortToProducerSort deriveSort
+  let inductiveName := constrainingInductive
+  let outputFVars := outputVars.map Expr.fvarId!
+  let mut outputIdxs : Array Nat := #[]
+  for i in [:constrArgs.size] do
+    let arg := constrArgs[i]!
+    if arg.isFVar && outputFVars.contains arg.fvarId! then
+      outputIdxs := outputIdxs.push i
+  if outputIdxs.isEmpty then
+    throwError m!"cannot find output indices, try specifying the implicit arguments"
+  let inductiveVal ← getConstInfoInduct inductiveName
+  let inductiveTypeComponents ← getComponentsOfArrowType inductiveVal.type
+  let argTypes := inductiveTypeComponents.pop
+  let argNames ← constrArgs.mapIdxM
+    (fun i (ident : Expr) =>
+      if ident.isFVar then ident.fvarId!.getUserName
+      else if let some outIdx := outputIdxs.findIdx? (· == i) then
+        outputVars[outIdx]!.fvarId!.getUserName
+      else throwError m!"{ident} is expected to be a variable.")
+  let argNamesTypes := argNames.zip argTypes
+  let _outputType ← tupleOfListM (throwError "no output types")
+    (fun t rest => mkAppM ``Prod #[t, rest]) outputTypes.toList
+  let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, localCtx) ←
+    withLocalDeclsDND argNamesTypes (fun _ => do
+      let mut localCtx ← getLCtx
+      let mut freshUnknowns := #[]
+      for argName in argNames do
+        let freshArgName := localCtx.getUnusedName argName
+        localCtx := localCtx.renameUserName argName freshArgName
+        freshUnknowns := freshUnknowns.push freshArgName
+      let freshenedOutputNames := outputIdxs.map (fun idx => freshUnknowns[idx]!)
+      let freshenedInputNamesExcludingOutput := freshUnknowns.toList.filter
+        (fun n => freshenedOutputNames.toList.all (· != n))
+      let outputNamesTypesIndices : List (Name × Expr × Nat) :=
+        (List.range outputIdxs.size).map (fun i =>
+          (freshenedOutputNames[i]!, outputTypes[i]!, outputIdxs[i]!))
+      let mut nonRecursiveProducers := #[]
+      let mut recursiveProducers := #[]
+      let freshFuelPrimeName := localCtx.getUnusedName `fuel'
+      let freshSizePrimeName := localCtx.getUnusedName `size'
+      let freshSize' := mkIdent freshSizePrimeName
+      let freshRecFnName := recFnNameOverride.getD (localCtx.getUnusedName (match deriveSort with
+        | .Generator => `aux_arb | .Enumerator => `aux_enum | _ => `aux_dec))
+      for ctorName in inductiveVal.ctors do
+        let scheduleOption ← (UnifyM.runInMetaM
+          (getProducerScheduleForInductiveConstructor inductiveName ctorName outputNamesTypesIndices
+            freshenedInputNamesExcludingOutput freshUnknowns deriveSort localCtx freshRecFnName)
+            emptyUnifyState)
+        match scheduleOption with
+        | some (scheduleSteps, scheduleSort) =>
+          let rewrittenSteps := scheduleRewriter scheduleSteps
+          let schedule := (rewrittenSteps, scheduleSort)
+          let (subProducer, _instances) ← StateT.run (s := #[]) (do
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) _outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+            MExp.mexpToTSyntax mexp deriveSort)
+          let isRecursive ← (isConstructorRecursive inductiveName ctorName) <||> pure (scheduleUsesMutualCall rewrittenSteps)
+          if isRecursive then
+            let subProducerTerm ← match producerSort with
+              | .Generator => `( ($(mkIdent ``Nat.succ) $freshSize', $subProducer) )
+              | .Enumerator => pure subProducer
+            recursiveProducers := recursiveProducers.push subProducerTerm
+          else
+            let subGeneratorTerm ← match producerSort with
+              | .Generator => `( (1, $subProducer) )
+              | .Enumerator => pure subProducer
+            nonRecursiveProducers := nonRecursiveProducers.push subGeneratorTerm
+        | none => throwError m!"Unable to derive producer schedule for constructor {ctorName}"
+      if nonRecursiveProducers.isEmpty && recursiveProducers.isEmpty then
+        throwError "Cannot derive constrained producer for '{inductiveName}': no constructor schedules were generated"
+      if nonRecursiveProducers.isEmpty then
+        throwError "Cannot derive constrained producer for '{inductiveName}': all constructors are recursive (no finite base case)"
+      let baseProducers ← `([$nonRecursiveProducers,*])
+      let inductiveProducers ← `([$nonRecursiveProducers,*, $recursiveProducers,*])
+      return (baseProducers, inductiveProducers, freshenedOutputNames, Lean.mkIdent <$> freshUnknowns, localCtx))
+  return (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, inductiveName, inductiveLevels, producerSort)
 
 
 private def deriveArbitrarySuchThatInstance'
@@ -893,4 +980,105 @@ def elabDeriveScheduledEnumerator : CommandElab := fun stx => do
 
     elabCommand typeClassInstance
 
+  | _ => throwUnsupportedSyntax
+
+/-! ## Mutual derivation command
+
+`derive_mutual` derives multiple constrained producers/checkers/enumerators simultaneously,
+allowing them to call each other for recursive/mutual-recursive relations.
+
+### Syntax:
+```
+derive_mutual
+  generator (fun τ => ∃ (Γ : List type) (e : term), typing Γ e τ),
+  generator_multi (∃ (Γ : List type) (e : term) (τ : type), typing Γ e τ),
+  checker (fun Γ e τ => typing Γ e τ)
+```
+
+Each entry is either `generator`, `generator_multi`, `enumerator`, or `checker` followed by
+a term describing the constraint. Currently each entry is derived independently in sequence.
+
+### TODO for true mutual recursion:
+To support cases where the derived functions need to call each other (e.g., "all outputs"
+typing depends on "fixed type" typing and vice versa), the following changes are needed:
+
+1. **Scheduler**: Generalize `recCall : Name × List Nat` to
+   `recCalls : List (Name × List Nat × Name)` where the third component is the
+   aux function name of the sibling spec to call.
+
+2. **isRecCall**: Check against ALL sibling specs. When a hypothesis matches a sibling
+   spec (same inductive, compatible output positions), emit `Source.Rec siblingAuxName args`.
+
+3. **Code generation**: Emit a `mutual ... end` block of top-level `def`s instead of
+   `let rec` inside an instance. Each instance then references its corresponding `def`.
+
+4. **MExp → TSyntax**: `Source.Rec` already handles calling by name, so no changes needed
+   once the schedule correctly identifies mutual calls.
+-/
+
+/-- Command for deriving multiple constrained generators in sequence,
+    each with multi-output hypothesis steps enabled.
+    Later entries can use instances derived by earlier ones. -/
+syntax (name := mutual_deriver) "derive_mutual" term,+ : command
+
+@[command_elab mutual_deriver]
+def elabDeriveMutual : CommandElab := fun stx => do
+  match stx with
+  | `(derive_mutual $entries,*) => do
+    withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
+      let specEntries := entries.getElems
+
+      -- Step 1: Parse all specs to get (inductiveName, outputIdxs) and assign global def names
+      let mut specMeta : Array (Name × List Nat × Name) := #[]
+      for i in [:specEntries.size] do
+        let entry := specEntries[i]!
+        let (indName, outIdxs) ← liftTermElabM do
+          let e ← elabTerm entry .none
+          lambdaTelescope e fun _args body => do
+            peelExistentialsAux body #[] #[] fun innerBody outVars _outTypes => do
+              innerBody.withApp fun ind indArgs => do
+                if !ind.isConst then throwError "Expected constant in derive_mutual spec"
+                let indName := ind.constName!
+                let outputFVars := outVars.map Expr.fvarId!
+                let mut idxs : Array Nat := #[]
+                for j in [:indArgs.size] do
+                  if indArgs[j]!.isFVar && outputFVars.contains indArgs[j]!.fvarId! then
+                    idxs := idxs.push j
+                return (indName, idxs.toList)
+        let globalName := Name.mkSimple s!"specimen_mutual_{indName.toString.replace "." "_"}_{i}"
+        specMeta := specMeta.push (indName, outIdxs, globalName)
+
+      let siblings := specMeta.toList
+
+      -- Step 2: Derive each spec, collecting (def, instance) pairs.
+      -- Uses mkConstrainedProducerMutualPieces which emits a standalone `def` + thin `instance`.
+      let mut defCmds : Array (TSyntax `command) := #[]
+      let mut instCmds : Array (TSyntax `command) := #[]
+      for i in [:specEntries.size] do
+        let entry := specEntries[i]!
+        let (_, _, globalName) := specMeta[i]!
+        let rewriter := fun steps => rewriteMutualCalls steps siblings
+        let (defCmd, instCmd) ← liftTermElabM do
+          let e ← elabTerm entry .none
+          withParsedDerivingArgs e fun args outVars outTypes indName indLevels indArgs => do
+            let parts ← deriveConstrainedProducerParts args outVars outTypes indName indLevels indArgs .Generator rewriter globalName
+            let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, _, inductiveLevels, producerSort) := parts
+            mkConstrainedProducerMutualPieces baseProducers inductiveProducers
+              indName inductiveLevels freshArgIdents freshenedOutputNames
+              outputTypes producerSort localCtx globalName
+        defCmds := defCmds.push defCmd
+        instCmds := instCmds.push instCmd
+
+      -- Step 3: Emit a `mutual ... end` block with all defs, then instances
+      let mutualCmd ← `(command| mutual $defCmds* end)
+      let mutualFormat ← liftCoreM (PrettyPrinter.ppCommand mutualCmd)
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty mutualFormat) (header := "Mutual block: ")
+      elabCommand mutualCmd
+
+      for instCmd in instCmds do
+        let genFormat ← liftCoreM (PrettyPrinter.ppCommand instCmd)
+        liftTermElabM $ Tactic.TryThis.addSuggestion stx
+          (Format.pretty genFormat) (header := "Try this instance: ")
+        elabCommand instCmd
   | _ => throwUnsupportedSyntax

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -116,6 +116,13 @@ structure ScheduleEnv where
   /-- When true, each hypothesis produces all available outputs at once -/
   multiOutput : Bool := false
 
+  /-- Sibling specs in a mutual derivation block.
+      Each entry is (inductiveName, outputIndices, auxFnName, siblingDeriveSort).
+      When a hypothesis matches a sibling (exact same inductive + output positions + compatible sort),
+      it emits Source.MutRec instead of Source.NonRec.
+      Currently only same-sort mutual calls are supported (gen↔gen, checker↔enum). -/
+  mutualSiblings : List (Name × List Nat × Name × DeriveSort) := []
+
 /-- A monad for deriving generator schedules. Under the hood,
     `ScheduleM` is just a reader monad stacked on top of `MetaM`,
     with `ScheduleEnv` serving as the environment for the reader monad. -/
@@ -1280,7 +1287,7 @@ private def possiblePreSchedules (vars : List TypedVar) (hypotheses : List Hypot
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [] ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1315,7 +1322,7 @@ private def possiblePreSchedulesWithAdvancedPruning (vars : List TypedVar) (hypo
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, multiOutput ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, multiOutput, [] ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1357,7 +1364,7 @@ private def possibleSchedules' (ctorName : Name) (vars : List TypedVar) (hypothe
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [] ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckSteps scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses

--- a/Specimen/GeneratorCombinators.lean
+++ b/Specimen/GeneratorCombinators.lean
@@ -2,6 +2,11 @@ import Plausible.Gen
 import Plausible.ArbitraryFueled
 open Plausible
 
+namespace Gen
+/-- Error thrown when a derived generator runs out of fuel (should not happen in practice) -/
+def outOfFuelError : GenError := .genError "Specimen: out of fuel (termination limit reached)"
+end Gen
+
 namespace GeneratorCombinators
 
 /-- `pick default xs n` chooses a weight & a generator `(k, gen)` from the list `xs` such that `n < k`.

--- a/Specimen/Idents.lean
+++ b/Specimen/Idents.lean
@@ -47,13 +47,15 @@ def pureFn : Ident := mkIdent $ Name.mkStr1 "pure"
 def trueIdent : Ident := mkIdent ``true
 def falseIdent : Ident := mkIdent ``false
 
--- Idents for size arguments to generators
+-- Idents for fuel and size arguments to generators
+def fuelIdent : Ident := mkIdent $ Name.mkStr1 "fuel"
 def initSizeIdent : Ident := mkIdent $ Name.mkStr1 "initSize"
 def sizeIdent : Ident := mkIdent $ Name.mkStr1 "size"
 
 /-- `Ident` representing `MonadExcept.throw`-/
 def failFn : Ident := mkIdent ``MonadExcept.throw
 def genericFailure : Ident := mkIdent ``Plausible.Gen.genericFailure
+def outOfFuelError : Ident := mkIdent `Gen.outOfFuelError
 
 -- Idents for typeclasses
 def arbitrarySizedSuchThatTypeclass : Ident := mkIdent $ Name.mkStr1 "ArbitrarySizedSuchThat"

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -190,12 +190,11 @@ partial def mexpToConstructorExpr (m : MExp) : Option ConstructorExpr :=
   | _ => none
 
 /-- `MExp` representation of a recursive function call,
-    where `f` is the function name, `sizePrimeName` is the (possibly freshened) name
-    for the `size'` parameter, and `args` are the arguments
-    (each represented as a `ConstructorExpr`) -/
-def recCall (f : Name) (sizePrimeName : Name) (args : List ConstructorExpr) : MExp :=
+    where `f` is the function name, `fuelPrimeName` is the name for `fuel'`,
+    `sizePrimeName` is for `size'`, and `args` are the input arguments -/
+def recCall (f : Name) (fuelPrimeName : Name) (sizePrimeName : Name) (args : List ConstructorExpr) : MExp :=
   .MApp .allowImplicit (.MId f) $
-    [.MId `initSize, .MId sizePrimeName] ++ (constructorExprToMExp .allExplicit <$> args)
+    [.MId fuelPrimeName, .MId `initSize, .MId sizePrimeName] ++ (constructorExprToMExp .allExplicit <$> args)
 
 /-- Converts a `HypothesisExpr` to an `MExp` -/
 def hypothesisExprToMExp (hypExpr : HypothesisExpr) : MExp :=
@@ -415,7 +414,7 @@ private def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr
       supplied to the generator/enumerator/checker we're deriving
 -/
 
-def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) (sizePrimeName : Name) : CompileScheduleM MExp :=
+def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) (fuelPrimeName : Name) (sizePrimeName : Name) : CompileScheduleM MExp :=
   match step with
   | .Unconstrained v src prodSort => do
     let monadSort := prodSortToMonadSort prodSort
@@ -425,8 +424,8 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
       let tyExpr := ToExpr.toExpr hyp
       let producer ← unconstrainedProducer prodSort ty
       pure $ .MBind monadSort producer [⟨v,tyExpr⟩] k
-    | Source.Rec f args =>
-      pure $ .MBind monadSort (recCall f sizePrimeName args) [⟨v, outputType⟩] k
+    | Source.Rec f args | Source.MutRec f args =>
+      pure $ .MBind monadSort (recCall f fuelPrimeName sizePrimeName args) [⟨v, outputType⟩] k
 
   | .SuchThat varsTys prod ps => do
     let monadSort := prodSortToOptionTMonadSort ps
@@ -435,8 +434,8 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
     | Source.NonRec hypExpr => do
       let producer ← constrainedProducer ps varsTys (hypothesisExprToMExp hypExpr) defFuel
       pure $ .MBind monadSort producer typedVars k
-    | Source.Rec f args =>
-      pure $ .MBind monadSort (recCall f sizePrimeName args) typedVars k
+    | Source.Rec f args | Source.MutRec f args =>
+      pure $ .MBind monadSort (recCall f fuelPrimeName sizePrimeName args) typedVars k
   | .Check src _ =>
 
     -- TODO: double check if we need to pattern-match on `scheduleSort` here
@@ -444,8 +443,8 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
       match src with
       | Source.NonRec hypExpr =>
         decOptChecker (hypothesisExprToMExp hypExpr) defFuel
-      | Source.Rec f args =>
-        recCall f sizePrimeName args
+      | Source.Rec f args | Source.MutRec f args =>
+        recCall f fuelPrimeName sizePrimeName args
 
     -- TODO: handle checking hypotheses w/ negative polarity (currently not handled)
 
@@ -459,7 +458,7 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
     - `mfuel` and `defFuel` are auxiliary `MExp`s representing the fuel
       for the function we are deriving (these correspond to `size` and `initSize`
       in the QuickChick code for the derived functions) -/
-def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recType : Expr) (sizePrimeName : Name := `size') : CompileScheduleM MExp :=
+def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recType : Expr) (fuelPrimeName : Name := `fuel') (sizePrimeName : Name := `size') : CompileScheduleM MExp :=
   let (scheduleSteps, scheduleSort) := schedule
   -- Determine the *epilogue* of the schedule (i.e. what happens after we
   -- have finished executing all the `scheduleStep`s)
@@ -485,5 +484,5 @@ def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recTyp
   -- Fold over the `scheduleSteps` and convert each of them to a functional `MExp`
   -- Note that the fold composes the `MExp`, and we use `foldr` since
   -- we want the `epilogue` to be the base-case of the fold
-  List.foldrM (fun step acc => scheduleStepToMExp step defFuel acc recType sizePrimeName)
+  List.foldrM (fun step acc => scheduleStepToMExp step defFuel acc recType fuelPrimeName sizePrimeName)
     epilogue scheduleSteps

--- a/Specimen/MakeConstrainedProducerInstance.lean
+++ b/Specimen/MakeConstrainedProducerInstance.lean
@@ -7,6 +7,7 @@ import Specimen.TSyntaxCombinators
 import Specimen.Idents
 import Specimen.Utils
 import Specimen.Schedules
+import Specimen.Debug
 
 
 open Lean Elab Command Meta Term Parser Std
@@ -85,31 +86,39 @@ def mkConstrainedProducerTypeClassInstance
   (targetTypes : List Expr)
   (producerSort : ProducerSort)
   (topLevelLocalCtx : LocalContext) : TermElabM (TSyntax `command) := do
-    -- Produce a fresh name for the `size` argument for the lambda
-    -- at the end of the generator function, as well as the `aux_arb` inner helper function
+    -- Produce fresh names for function parameters
     let freshSizeIdent := mkFreshAccessibleIdent topLevelLocalCtx `size
     let freshSize' := mkFreshAccessibleIdent topLevelLocalCtx `size'
+    let freshFuel' := mkFreshAccessibleIdent topLevelLocalCtx `fuel'
 
     -- The (backtracking) combinator to be invoked
-    -- (`GeneratorCombinators.backtrack` for generators, `EnumeratorCombinators.enumerate` for enumerators)
     let combinatorFn :=
       match producerSort with
       | .Generator => genBacktrackFn
       | .Enumerator => enumerateFn
 
-    -- Create the cases for the pattern-match on the size argument
-    let mut caseExprs := #[]
+    -- Create the inner match on size (base vs recursive constructors)
+    let mut sizeCaseExprs := #[]
     let zeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $combinatorFn $baseGenerators)
-    caseExprs := caseExprs.push zeroCase
+    sizeCaseExprs := sizeCaseExprs.push zeroCase
 
     let succCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshSize' => $combinatorFn $inductiveGenerators)
-    caseExprs := caseExprs.push succCase
+    sizeCaseExprs := sizeCaseExprs.push succCase
 
-    -- Create function arguments for the producer's `size` & `initSize` parameters
-    -- (former is the generator size, latter is the size argument with which to invoke other auxiliary producers/checkers)
+    let sizeMatchExpr ← mkMatchExpr sizeIdent sizeCaseExprs
+
+    -- Wrap with outer fuel match for termination
+    let mut fuelCaseExprs := #[]
+    let fuelZeroCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $failFn $outOfFuelError)
+    fuelCaseExprs := fuelCaseExprs.push fuelZeroCase
+    let fuelSuccCase ← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshFuel' => $sizeMatchExpr)
+    fuelCaseExprs := fuelCaseExprs.push fuelSuccCase
+    let matchExpr ← mkMatchExpr fuelIdent fuelCaseExprs
+
+    -- Create function arguments for the producer's `fuel`, `initSize` & `size` parameters
+    let fuelParam ← `(Term.letIdBinder| ($fuelIdent : $natIdent))
     let initSizeParam ← `(Term.letIdBinder| ($initSizeIdent : $natIdent))
     let sizeParam ← `(Term.letIdBinder| ($sizeIdent : $natIdent))
-    let matchExpr ← mkMatchExpr sizeIdent caseExprs
 
     -- Add parameters for each argument to the inductive relation
     -- (except the target variables, which we'll filter out later)
@@ -119,6 +128,7 @@ def mkConstrainedProducerTypeClassInstance
 
     -- Inner params are for the inner `aux_arb` / `aux_enum` function
     let mut innerParams := #[]
+    innerParams := innerParams.push fuelParam
     innerParams := innerParams.push initSizeParam
     innerParams := innerParams.push sizeParam
 
@@ -197,9 +207,123 @@ def mkConstrainedProducerTypeClassInstance
 
     let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
 
+    let fuelVal := Lean.Option.get (← getOptions) specimen.fuel
+    let fuelLit := Syntax.mkNumLit (toString fuelVal)
+
     -- Produce an instance of the appropriate typeclass containing the definition for the derived producer
     `(instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
         $producerTypeClassFunction:ident :=
           let rec $innerFunctionIdent:ident $innerParams* $arbitraryTypeParamInstances:bracketedBinder* : $optionTProducerType :=
             $matchExpr
-          fun $freshSizeIdent => $innerFunctionIdent $freshSizeIdent $freshSizeIdent $outerParams*)
+          fun $freshSizeIdent => $innerFunctionIdent $fuelLit $freshSizeIdent $freshSizeIdent $outerParams*)
+
+/-- Like `mkConstrainedProducerTypeClassInstance` but returns the function body and metadata
+    separately, for use in `mutual def` blocks.
+    Returns: (matchExpr, innerParams, returnType, outerParams, instanceMetadata) -/
+def mkConstrainedProducerMutualPieces
+  (baseGenerators : TSyntax `term) (inductiveGenerators : TSyntax `term)
+  (inductiveName : Name) (inductiveLevels : List Level)
+  (args : TSyntaxArray `term) (targetVars : Array Name)
+  (targetTypes : Array Expr) (producerSort : ProducerSort)
+  (topLevelLocalCtx : LocalContext) (globalDefName : Name) :
+  TermElabM (TSyntax `command × TSyntax `command) := do
+    -- Reuse the same computation as mkConstrainedProducerTypeClassInstance
+    let freshSizeIdent := mkFreshAccessibleIdent topLevelLocalCtx `size
+    let freshSize' := mkFreshAccessibleIdent topLevelLocalCtx `size'
+    let freshFuel' := mkFreshAccessibleIdent topLevelLocalCtx `fuel'
+
+    let combinatorFn := match producerSort with
+      | .Generator => genBacktrackFn
+      | .Enumerator => enumerateFn
+
+    let mut sizeCaseExprs := #[]
+    sizeCaseExprs := sizeCaseExprs.push (← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $combinatorFn $baseGenerators))
+    sizeCaseExprs := sizeCaseExprs.push (← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshSize' => $combinatorFn $inductiveGenerators))
+    let sizeMatchExpr ← mkMatchExpr sizeIdent sizeCaseExprs
+
+    let mut fuelCaseExprs := #[]
+    fuelCaseExprs := fuelCaseExprs.push (← `(Term.matchAltExpr| | $(mkIdent ``Nat.zero) => $failFn $outOfFuelError))
+    fuelCaseExprs := fuelCaseExprs.push (← `(Term.matchAltExpr| | $(mkIdent ``Nat.succ) $freshFuel' => $sizeMatchExpr))
+    let matchExpr ← mkMatchExpr fuelIdent fuelCaseExprs
+
+    let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
+    let targetVarsList := targetVars.toList
+
+    -- Build the function type: Nat → Nat → Nat → param types → Gen α
+    let mut paramTypes : Array (TSyntax `term) := #[natIdent, natIdent, natIdent]
+    let mut outerParams : Array (TSyntax `term) := #[]
+    let mut outputTypeSyntaxes : Array (TSyntax `term) := #[]
+    let mut typeParams := #[]
+    -- Build inner params for the lambda
+    let mut innerParamBinders : Array (TSyntax `term) := #[]
+    innerParamBinders := innerParamBinders.push (← `(($fuelIdent : $natIdent)))
+    innerParamBinders := innerParamBinders.push (← `(($initSizeIdent : $natIdent)))
+    innerParamBinders := innerParamBinders.push (← `(($sizeIdent : $natIdent)))
+
+    for (paramName, paramType, paramTypeSyntax) in paramInfo do
+      if paramType.isSort then
+        typeParams := typeParams.push paramName
+      if paramName ∉ targetVarsList then
+        outerParams := outerParams.push (mkIdent paramName)
+        paramTypes := paramTypes.push paramTypeSyntax
+        if paramType.isSort then
+          innerParamBinders := innerParamBinders.push (← `(($(mkIdent paramName) : Sort _)))
+        else
+          innerParamBinders := innerParamBinders.push (← `(($(mkIdent paramName) : $paramTypeSyntax)))
+      else
+        outputTypeSyntaxes := outputTypeSyntaxes.push paramTypeSyntax
+
+    let targetTypeSyntax ← do
+      let syns ← if outputTypeSyntaxes.isEmpty then
+        targetTypes.mapM (fun ty => PrettyPrinter.delab ty)
+      else pure outputTypeSyntaxes
+      let rec mkProdType : List (TSyntax `term) → TermElabM (TSyntax `term)
+        | [] => throwError "no output types found"
+        | [t] => pure t
+        | t :: ts => do let rest ← mkProdType ts; `($t × $rest)
+      mkProdType syns.toList
+
+    let targetVarPattern : TSyntax `term ← do
+      let rec mkProdPat : List Name → TermElabM (TSyntax `term)
+        | [] => throwError "no output variables"
+        | [v] => `($(Lean.mkIdent v))
+        | v :: vs => do let rest ← mkProdPat vs; `(($(Lean.mkIdent v), $rest))
+      mkProdPat targetVars.toList
+
+    let optionTProducerType ← match producerSort with
+      | .Generator => `($genTypeConstructor $targetTypeSyntax)
+      | .Enumerator => `($exceptTTypeConstructor $genErrorType $enumTypeConstructor $targetTypeSyntax)
+
+    -- Build the full function type for the def
+    let mut fullType ← pure optionTProducerType
+    for pt in paramTypes.reverse do
+      fullType ← `($pt → $fullType)
+
+    -- Build the lambda body
+    let lambdaBody ← `(fun $innerParamBinders* => $matchExpr)
+
+    -- Emit the def
+    let defIdent := mkIdent globalDefName
+    let defCmd ← `(command| def $defIdent : $fullType := $lambdaBody)
+
+    -- Emit the instance
+    let producerTypeClass := match producerSort with
+      | .Generator => arbitrarySizedSuchThatTypeclass
+      | .Enumerator => enumSizedSuchThatTypeclass
+    let producerTypeClassFunction := match producerSort with
+      | .Generator => unqualifiedArbitrarySizedSTFn
+      | .Enumerator => unqualifiedEnumSizedSTFn
+    let producerUnconstrainedClass := match producerSort with
+      | .Generator => ``Plausible.Arbitrary
+      | .Enumerator => ``Enum
+    let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
+    let fuelVal := Lean.Option.get (← getOptions) specimen.fuel
+    let fuelLit := Syntax.mkNumLit (toString fuelVal)
+    let callArgs : TSyntaxArray `term := #[(⟨fuelLit⟩ : TSyntax `term), (freshSizeIdent : TSyntax `term), (freshSizeIdent : TSyntax `term)] ++ (TSyntaxArray.mk outerParams)
+    let callExpr ← `($defIdent $callArgs*)
+    let instCmd ← `(command|
+      instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
+        $producerTypeClassFunction:ident := fun $freshSizeIdent => $callExpr)
+
+    return (defCmd, instCmd)
+

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -28,6 +28,7 @@ local instance [Ord α][Ord β]: Ord (α × β) := lexOrd
 inductive Source
   | NonRec : HypothesisExpr → Source
   | Rec : Name → List ConstructorExpr → Source
+  /-- A call to a sibling spec in a mutual block (distinct global def name). -/
   | MutRec : Name → List ConstructorExpr → Source
   deriving Repr, BEq
 

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -28,6 +28,7 @@ local instance [Ord α][Ord β]: Ord (α × β) := lexOrd
 inductive Source
   | NonRec : HypothesisExpr → Source
   | Rec : Name → List ConstructorExpr → Source
+  | MutRec : Name → List ConstructorExpr → Source
   deriving Repr, BEq
 
 /-- Producers are either enumerators or generators -/
@@ -92,6 +93,7 @@ inductive ScheduleStep
 /-- Stringifier for `Source` -/
 def sourceToString source := match source with
   | Source.Rec name ctrArgs => s!"{ToExpr.toExpr (name,ctrArgs)}"
+  | Source.MutRec name ctrArgs => s!"mut:{ToExpr.toExpr (name,ctrArgs)}"
   | Source.NonRec hyp => s!"{ToExpr.toExpr hyp}"
 
 def patternToString pat := s!"{ToExpr.toExpr $ constructorExprOfPattern pat}"
@@ -225,6 +227,9 @@ def updateSource (k : UnknownMap) (src : Source) : UnifyM Source := do
   | .Rec r tys => do
     let updatedTys ← List.mapM (UnifyM.updateConstructorArg k) tys
     return .Rec r updatedTys
+  | .MutRec r tys => do
+    let updatedTys ← List.mapM (UnifyM.updateConstructorArg k) tys
+    return .MutRec r updatedTys
 
 /-- Updates a list of `ScheduleSteps` with the result of unification -/
 def updateScheduleSteps (scheduleSteps : List ScheduleStep) : UnifyM (List ScheduleStep) := do
@@ -262,5 +267,50 @@ def addConclusionPatternsAndEqualitiesToSchedule (patterns : List (Unknown × Pa
   -- We should never have an equality here. Assertion after unification should handle that though.
   let equalityCheckSteps := (fun (u1, u2) => ScheduleStep.Check (Source.NonRec (``Eq, [.Unknown u1, .Unknown u2])) true) <$> equalities.toList
   (matchSteps ++ equalityCheckSteps ++ existingScheduleSteps, scheduleSort)
+
+/-- Rewrites `Source.NonRec` calls in schedule steps to `Source.MutRec` when the hypothesis
+    matches a sibling spec exactly (same inductive name AND same number of output variables).
+    `siblings` is `(inductiveName, outputIndices, auxFnName)`. -/
+def rewriteMutualCalls (steps : List ScheduleStep) (siblings : List (Name × List Nat × Name)) : List ScheduleStep :=
+  let matchesSibling (hyp : HypothesisExpr) (numOutputs : Nat) : Option (Name × List Nat) :=
+    let (hypName, hypArgs) := hyp
+    let numInputs := hypArgs.length - numOutputs
+    siblings.findSome? fun (indName, outputIdxs, auxName) =>
+      if hypName == indName && outputIdxs.length == numOutputs && (hypArgs.length - outputIdxs.length) == numInputs then
+        some (auxName, outputIdxs)
+      else none
+  steps.map fun step =>
+    match step with
+    | .SuchThat vs (.NonRec hyp) ps =>
+      match matchesSibling hyp vs.length with
+      | some (auxName, outputIdxs) =>
+        let (_, hypArgs) := hyp
+        let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
+        .SuchThat vs (.MutRec auxName inputArgs) ps
+      | none => step
+    | .Unconstrained v (.NonRec hyp) ps =>
+      match matchesSibling hyp 1 with
+      | some (auxName, outputIdxs) =>
+        let (_, hypArgs) := hyp
+        let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
+        .Unconstrained v (.MutRec auxName inputArgs) ps
+      | none => step
+    | .Check (.NonRec hyp) pol =>
+      match matchesSibling hyp 0 with
+      | some (auxName, outputIdxs) =>
+        let (_, hypArgs) := hyp
+        let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
+        .Check (.MutRec auxName inputArgs) pol
+      | none => step
+    | other => other
+
+/-- Checks if any step in a schedule uses `Source.MutRec`. -/
+def scheduleUsesMutualCall (steps : List ScheduleStep) : Bool :=
+  steps.any fun step =>
+    match step with
+    | .Unconstrained _ (.MutRec ..) _ => true
+    | .SuchThat _ (.MutRec ..) _ => true
+    | .Check (.MutRec ..) _ => true
+    | _ => false
 
 end Schedules

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
@@ -5,46 +5,34 @@ import SpecimenTest.DeriveArbitrary.DeriveSTLCTermTypeGenerators
 import SpecimenTest.DeriveDecOpt.DeriveSTLCChecker
 import SpecimenTest.DeriveArbitrarySuchThat.DeriveSTLCGenerator
 
-/-! Test: multi-output constrained generation for STLC.
-    Generate both a well-typed term AND its type given a context. -/
+/-! Test: mutual multi-output constrained generation for STLC.
+
+    Uses derive_mutual to derive all input/output splits of `typing` and `lookup`
+    simultaneously. The mutual block handles circular dependencies between
+    "all outputs" typing (needs "τ fixed" for TAdd) and
+    "τ fixed" typing (needs "all outputs" for TApp). -/
 
 open Plausible
 
 set_option guard_msgs.diff true
 
--- Generate both a term and its type given a context Γ (standard mode)
+-- Derive all mutual dependencies together
 #guard_msgs(drop info) in
-derive_generator (fun Γ => ∃ (e : term) (τ : type), typing Γ e τ)
+derive_mutual
+  (∃ (Γ : List type) (x : Nat) (τ : type), lookup Γ x τ),
+  (fun τ => ∃ (Γ : List type) (x : Nat), lookup Γ x τ),
+  (∃ (Γ : List type) (e : term) (τ : type), typing Γ e τ),
+  (fun τ => ∃ (Γ : List type) (e : term), typing Γ e τ)
 
-/-! ## Multi-output mode for non-recursive relations -/
-
--- Multi-output lookup: all three as outputs
+-- Verify instances
 #guard_msgs(drop info) in
-derive_generator_multi (∃ (Γ : List type) (x : Nat) (τ : type), lookup Γ x τ)
+#check (inferInstance : ArbitrarySizedSuchThat (List type × term × type) (fun (Γ, e, τ) => typing Γ e τ))
 
--- Multi-output lookup: τ as input, Γ and x as outputs
 #guard_msgs(drop info) in
-derive_generator_multi (fun τ => ∃ (Γ : List type) (x : _), lookup Γ x τ)
+#check (inferInstance : ArbitrarySizedSuchThat (List type × term) (fun (Γ, e) => typing Γ e .Nat))
 
--- Verify the instance type
-#guard_msgs(drop info) in
-#check (inferInstance : ArbitrarySizedSuchThat (term × type) (fun (e, τ) => typing [] e τ))
-
--- Sample: generate a well-typed closed term along with its type
-#guard_msgs(drop info) in
-#eval do
+-- Sample: generate a well-typed term with its context and type
+#eval! do
   let sample ← Gen.run
-    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : term × type) => typing [] p.1 p.2) 5) 10
-  return repr sample
-
--- Generate both an index and a type from a lookup judgment given a context
-#guard_msgs(drop info) in
-derive_generator (fun Γ => ∃ (x : Nat) (τ : type), lookup Γ x τ)
-
--- Sample: generate a valid (index, type) pair for a non-empty context
-#guard_msgs(drop info) in
-#eval do
-  let ctx : List type := [.Nat, .Fun .Nat .Nat, .Nat]
-  let sample ← Gen.run
-    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : Nat × type) => lookup ctx p.1 p.2) 5) 10
+    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : List type × term × type) => typing p.1 p.2.1 p.2.2) 3) 10
   return repr sample

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
@@ -34,5 +34,5 @@ derive_mutual
 -- Sample: generate a well-typed term with its context and type
 #eval! do
   let sample ← Gen.run
-    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : List type × term × type) => typing p.1 p.2.1 p.2.2) 3) 10
+    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : List type × term × type) => let (Γ, e, τ) := p; typing Γ e τ) 3) 10
   return repr sample

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -29,10 +29,10 @@ set_option match.ignoreUnusedAlts true
 -- ============================================================
 
 /--
-info: def instArbitrarySizedSuchThatNatBetween.aux_arb : Nat → Nat → Nat → Nat → Gen Nat :=
-fun initSize size lo_1 hi_1 =>
-  Nat.brecOn (motive := fun size => Nat → Gen Nat) size (instArbitrarySizedSuchThatNatBetween.aux_arb._f initSize lo_1)
-    hi_1
+info: def instArbitrarySizedSuchThatNatBetween.aux_arb : Nat → Nat → Nat → Nat → Nat → Gen Nat :=
+fun fuel initSize size lo_1 hi_1 =>
+  Nat.brecOn (motive := fun fuel => Nat → Nat → Gen Nat) fuel
+    (instArbitrarySizedSuchThatNatBetween.aux_arb._f initSize lo_1) size hi_1
 -/
 #guard_msgs in
 #print instArbitrarySizedSuchThatNatBetween.aux_arb
@@ -42,10 +42,10 @@ fun initSize size lo_1 hi_1 =>
 -- ============================================================
 
 /--
-info: def instArbitrarySizedSuchThatBinaryTreeBST.aux_arb : Nat → Nat → Nat → Nat → Gen BinaryTree :=
-fun initSize size lo_1 hi_1 =>
-  Nat.brecOn (motive := fun size => Nat → Nat → Gen BinaryTree) size
-    (instArbitrarySizedSuchThatBinaryTreeBST.aux_arb._f initSize) lo_1 hi_1
+info: def instArbitrarySizedSuchThatBinaryTreeBST.aux_arb : Nat → Nat → Nat → Nat → Nat → Gen BinaryTree :=
+fun fuel initSize size lo_1 hi_1 =>
+  Nat.brecOn (motive := fun fuel => Nat → Nat → Nat → Gen BinaryTree) fuel
+    (instArbitrarySizedSuchThatBinaryTreeBST.aux_arb._f initSize) size lo_1 hi_1
 -/
 #guard_msgs in
 #print instArbitrarySizedSuchThatBinaryTreeBST.aux_arb
@@ -55,10 +55,10 @@ fun initSize size lo_1 hi_1 =>
 -- ============================================================
 
 /--
-info: def instArbitrarySizedSuchThatTermTyping.aux_arb : Nat → Nat → List type → type → Gen term :=
-fun initSize size G_1 t_1 =>
-  Nat.brecOn (motive := fun size => List type → type → Gen term) size
-    (instArbitrarySizedSuchThatTermTyping.aux_arb._f initSize) G_1 t_1
+info: def instArbitrarySizedSuchThatTermTyping.aux_arb : Nat → Nat → Nat → List type → type → Gen term :=
+fun fuel initSize size G_1 t_1 =>
+  Nat.brecOn (motive := fun fuel => Nat → List type → type → Gen term) fuel
+    (instArbitrarySizedSuchThatTermTyping.aux_arb._f initSize) size G_1 t_1
 -/
 #guard_msgs in
 #print instArbitrarySizedSuchThatTermTyping.aux_arb
@@ -68,10 +68,10 @@ fun initSize size G_1 t_1 =>
 -- ============================================================
 
 /--
-info: def instArbitrarySizedSuchThatListNatExpMatch.aux_arb : Nat → Nat → RegExp → Gen (List Nat) :=
-fun initSize size re_1 =>
-  Nat.brecOn (motive := fun size => RegExp → Gen (List Nat)) size
-    (instArbitrarySizedSuchThatListNatExpMatch.aux_arb._f initSize) re_1
+info: def instArbitrarySizedSuchThatListNatExpMatch.aux_arb : Nat → Nat → Nat → RegExp → Gen (List Nat) :=
+fun fuel initSize size re_1 =>
+  Nat.brecOn (motive := fun fuel => Nat → RegExp → Gen (List Nat)) fuel
+    (instArbitrarySizedSuchThatListNatExpMatch.aux_arb._f initSize) size re_1
 -/
 #guard_msgs in
 #print instArbitrarySizedSuchThatListNatExpMatch.aux_arb
@@ -93,8 +93,10 @@ derive_checker (fun xs n => MemNat xs n)
 derive_generator (fun n => ∃ xs, MemNat xs n)
 
 /--
-info: def instArbitrarySizedSuchThatListNatMemNat.aux_arb : Nat → Nat → Nat → Gen (List Nat) :=
-fun initSize size n_1 => Nat.brecOn size (instArbitrarySizedSuchThatListNatMemNat.aux_arb._f initSize n_1)
+info: def instArbitrarySizedSuchThatListNatMemNat.aux_arb : Nat → Nat → Nat → Nat → Gen (List Nat) :=
+fun fuel initSize size n_1 =>
+  Nat.brecOn (motive := fun fuel => Nat → Gen (List Nat)) fuel
+    (instArbitrarySizedSuchThatListNatMemNat.aux_arb._f initSize n_1) size
 -/
 #guard_msgs in
 #print instArbitrarySizedSuchThatListNatMemNat.aux_arb


### PR DESCRIPTION
## Summary

Introduces the `derive_mutual` command for deriving constrained producers (generators, enumerators, checkers) that are mutually recursive. This is the core infrastructure that enables deriving generators for relations like STLC typing where `typing` and `lookup` depend on each other.

### Fuel/size separation

Splits the single `size` parameter into two:
- **`fuel`** — decremented on every recursive/mutual call, ensures termination
- **`size`** — controls depth/complexity of generated terms, passed to unconstrained producers

This separation is prerequisite for mutual recursion: mutual calls share the same `fuel` for termination while `size` controls depth independently.

### Mutual recursion infrastructure

- **`Source.MutRec`** variant in `Schedules.lean` — represents cross-spec recursive calls (distinct from self-recursive `Source.Rec`)
- **`rewriteMutualCalls`** post-pass — detects when a schedule step references a sibling spec and rewrites `Source.Rec` to `Source.MutRec` with the sibling's global def name
- **`compileInductiveSchedule`** — new compilation path that takes pre-derived `InductiveSchedule`s and compiles them with sibling awareness (rewrites both self-recursive and mutual calls)
- **Lean `mutual` block emission** — emits proper `mutual ... end` blocks with type signatures for mutually-recursive definitions
- **SCC-based compilation** — uses Tarjan's algorithm to identify strongly-connected components and emit them as mutual blocks

### Usage

```lean
derive_mutual
  (fun Γ τ => ∃ e, typing Γ e τ),
  (fun Γ x τ => lookup Γ x τ)
```

Each entry specifies a relation to derive. Entries in the same SCC are compiled into a shared `mutual` block.

### Depends on

- #4 (multi-output support)

## Test plan

- [x] `MultiOutputSTLCTest.lean` — mutual derivation of `typing` and `lookup`
- [x] `ScheduleQualityRegressionTest.lean` — regression test updated for fuel/size
- [x] All 116 existing test jobs pass without regression

---
*PR 2 of 5 (stacked): multi-output → **derive_mutual** → auto-derive → fixes → HTML infoview*