### PR TITLE
Add auto-derive dependency discovery and checker/enumerator support

### DIFF
--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -21,6 +21,13 @@ register_option specimen.fuel : Nat := {
   descr := "fuel (termination budget) for derived generators/enumerators/checkers"
 }
 
+/-- When true, derive_mutual automatically derives dependencies for other inductives
+    referenced in the specs' constructors before emitting the mutual block. -/
+register_option specimen.autoDeriveDeps : Bool := {
+  defValue := false
+  descr := "automatically derive dependency instances in derive_mutual"
+}
+
 /-- Global flag for enabling/disabling debug messages -/
 def globalDebugFlag : Bool := false
 

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -770,6 +770,317 @@ def deriveConstrainedProducer
     producerSort
     localCtx
 
+/-- Compiles an InductiveSchedule from the memo into (def, instance) commands.
+    Uses the pre-derived schedules directly (no re-derivation).
+    `siblings` is the list of specs in the same mutual block (for rewriting to Source.MutRec). -/
+def compileInductiveSchedule (indSched : InductiveSchedule)
+    (globalName : Name) (siblings : List (Name × List Nat × Name × DeriveSort))
+    : TermElabM (TSyntax `command × TSyntax `command) := do
+  let key := indSched.key
+  let indInfo ← getConstInfoInduct key.inductiveName
+  let indLevels := indInfo.levelParams.map (Level.param ·)
+  let indTypeComponents ← getComponentsOfArrowType indInfo.type
+  let argTypes := indTypeComponents.pop
+  -- Use the SAME freshened names that derivation used (stored in indSched.argNames)
+  let argNameTypes : Array (Name × Expr) := Id.run do
+    let mut r := #[]
+    for i in [:argTypes.size] do
+      let name := indSched.argNames.getD i (Name.mkSimple s!"arg_{i}")
+      r := r.push (name, argTypes[i]!)
+    r
+  withLocalDeclsDND argNameTypes fun _allFVars => do
+    -- Filter out Sort-typed positions from outputs (those are type params, handled by instance binders)
+    let outputIndicesNonSort := key.outputIndices.filter (fun i =>
+      match argTypes[i]? with | some ty => !ty.isSort | none => true)
+    let outputTypes := outputIndicesNonSort.filterMap (fun i => argTypes[i]?)
+    -- Compile each constructor schedule to a sub-producer term
+    let outputType ← tupleOfListM (throwError "no output types")
+      (fun t rest => mkAppM ``Prod #[t, rest]) outputTypes
+    let producerSort := convertDeriveSortToProducerSort key.deriveSort
+    let freshFuelPrimeName := `fuel'
+    let freshSizePrimeName := `size'
+    let mut nonRecursiveProducers : Array (TSyntax `term) := #[]
+    let mut recursiveProducers : Array (TSyntax `term) := #[]
+    let freshSize' := Lean.mkIdent freshSizePrimeName
+    -- Helper: rewrite Source.Rec to use globalName + rewrite sibling calls
+    let rewriteSchedule := fun (steps : List ScheduleStep) =>
+      let mutRewritten := rewriteMutualCalls steps siblings
+      -- Also rewrite Source.Rec (self-recursive) to use globalName
+      mutRewritten.map fun step =>
+        match step with
+        | .Unconstrained v (.Rec _ args) ps => .Unconstrained v (.Rec globalName args) ps
+        | .SuchThat vs (.Rec _ args) ps => .SuchThat vs (.Rec globalName args) ps
+        | .Check (.Rec _ args) pol => .Check (.Rec globalName args) pol
+        | other => other
+    for (_, schedule) in indSched.baseSchedules do
+      let (steps, sort) := schedule
+      let rewrittenSchedule := (rewriteSchedule steps, sort)
+      let (subProducer, _) ← StateT.run (s := #[]) (do
+        let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
+          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+        MExp.mexpToTSyntax mexp key.deriveSort)
+      let term ← match key.deriveSort with
+        | .Generator => `( (1, $subProducer) )
+        | .Enumerator => pure subProducer
+        | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
+      nonRecursiveProducers := nonRecursiveProducers.push term
+    for (_, schedule) in indSched.recSchedules do
+      let (steps, sort) := schedule
+      let rewrittenSchedule := (rewriteSchedule steps, sort)
+      let (subProducer, _) ← StateT.run (s := #[]) (do
+        let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
+          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+        MExp.mexpToTSyntax mexp key.deriveSort)
+      let term ← match key.deriveSort with
+        | .Generator => `( ($(Lean.mkIdent ``Nat.succ) $freshSize', $subProducer) )
+        | .Enumerator => pure subProducer
+        | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
+      recursiveProducers := recursiveProducers.push term
+    let baseProducers ← `([$nonRecursiveProducers,*])
+    let inductiveProducers ← `([$nonRecursiveProducers,*, $recursiveProducers,*])
+    let freshArgIdents : TSyntaxArray `term := argNameTypes.map (fun (n, _) => Lean.mkIdent n)
+    let freshenedOutputNames := outputIndicesNonSort.filterMap (fun i => argNameTypes[i]?.map (·.1))
+    mkConstrainedProducerMutualPieces baseProducers inductiveProducers
+      key.inductiveName indLevels freshArgIdents freshenedOutputNames
+      outputTypes producerSort (← getLCtx) globalName key.deriveSort
+
+/-- Recursively derives the best schedule for a SpecKey, populating the memo with
+    all transitive dependencies. Returns the score for this spec.
+
+    Follows QuickChick's `inductive_best_valid_schedule` pattern:
+    1. Check memo (return cached if found, or optimistic score if inProgress/cycle)
+    2. Check if instance already exists (return totalScore)
+    3. Insert inProgress placeholder
+    4. Derive schedules for each constructor
+    5. Collect NonRec deps from chosen schedules → recursively derive
+    6. Store result in memo -/
+partial def deriveBestInductiveSchedule (key : SpecKey)
+    (memo : IO.Ref (Std.HashMap SpecKey MemoEntry))
+    (scheduleRewriter : List ScheduleStep → List ScheduleStep := id) : TermElabM SpecScore := do
+  -- 1. Check memo
+  let current ← memo.get
+  match current[key]? with
+  | some .inProgress => return {}  -- cycle: optimistic (mutual call = cheap)
+  | some (.done indSched) => return indSched.score
+  | some (.failed _) => return { unconstrained := 1 }  -- user must provide; assume partial quality
+  | none => pure ()
+
+  -- 2. Check if instance already exists — skip derivation if so
+  -- Uses getCorrectTypes pattern: apply inductive to args one at a time for proper dependent types
+  let indInfo ← getConstInfoInduct key.inductiveName
+  let indTypeComponents ← getComponentsOfArrowType indInfo.type
+  let argTypes := indTypeComponents.pop
+  let nonSortOutputIndices := key.outputIndices.filter (fun i =>
+    match argTypes[i]? with | some ty => !ty.isSort | none => true)
+  let instanceExists ← Meta.withNewMCtxDepth do
+    try
+      if nonSortOutputIndices.isEmpty && key.outputIndices.length > 0 then pure true
+      else if nonSortOutputIndices.isEmpty then pure false
+      else
+        -- Build properly-typed fvars by applying the inductive one arg at a time
+        -- Then nest withLocalDecl for each + instImplicit for Sort-typed params
+        -- Use Level.succ (fresh mvar) for each universe param — ensures Type level (not Prop)
+        let indLevelsForCheck ← indInfo.levelParams.mapM (fun _ => do
+          let lv ← Meta.mkFreshLevelMVar
+          pure (.succ lv))
+        let numArgs := argTypes.size
+        let rec buildAndCheck (idx : Nat) (t : Expr) (fvars : Array Expr) (instIdx : Nat) : TermElabM Bool :=
+          if idx >= numArgs then do
+            -- All fvars created — now build predicate and try synthesis
+            let outputFVars := nonSortOutputIndices.filterMap (fun i => fvars[i]?)
+            let outputTypes ← outputFVars.mapM (fun e => inferType e)
+            let outType ← tupleOfListM (throwError "empty")
+              (fun t' rest => mkAppM ``Prod #[t', rest]) outputTypes
+            withLocalDecl `x .default outType fun xFvar => do
+              let mut projections : Array Expr := #[]
+              let mut currentExpr := xFvar
+              for i in [:outputFVars.length] do
+                if outputFVars.length == 1 then projections := projections.push currentExpr
+                else if i < outputFVars.length - 1 then
+                  projections := projections.push (← mkAppM ``Prod.fst #[currentExpr])
+                  currentExpr ← mkAppM ``Prod.snd #[currentExpr]
+                else projections := projections.push currentExpr
+              let mut appArgs : Array Expr := #[]
+              let mut outIdx := 0
+              for i in [:fvars.size] do
+                if i ∈ nonSortOutputIndices then
+                  appArgs := appArgs.push projections[outIdx]!
+                  outIdx := outIdx + 1
+                else
+                  appArgs := appArgs.push fvars[i]!
+              let body := mkAppN (.const key.inductiveName indLevelsForCheck) appArgs
+              let pred ← mkLambdaFVars #[xFvar] body
+              let ty ← mkAppM ``ArbitrarySizedSuchThat #[outType, pred]
+              let result ← Meta.synthInstance? ty
+              pure result.isSome
+          else do
+            -- Get the type of the next arg from the partially-applied inductive
+            let argTy := (← inferType t).bindingDomain!
+            let name := Name.mkSimple s!"arg_{idx}"
+            let bi := if argTy.isSort then BinderInfo.implicit else .default
+            withLocalDecl name bi argTy fun fv => do
+              -- If Sort-typed, add Arbitrary + DecidableEq instance fvars
+              if argTy.isSort then
+                let arbTy ← mkAppM ``Plausible.Arbitrary #[fv]
+                let decEqTy ← mkAppM ``DecidableEq #[fv]
+                withLocalDecl (Name.mkSimple s!"inst_arb_{instIdx}") .instImplicit arbTy fun _ =>
+                withLocalDecl (Name.mkSimple s!"inst_deceq_{instIdx}") .instImplicit decEqTy fun _ =>
+                  buildAndCheck (idx + 1) (.app t fv) (fvars.push fv) (instIdx + 1)
+              else
+                buildAndCheck (idx + 1) (.app t fv) (fvars.push fv) instIdx
+        buildAndCheck 0 (.const key.inductiveName indLevelsForCheck) #[] 0
+    catch _ => pure false
+  if instanceExists then
+    let trivialSched : InductiveSchedule := { key, argNames := [], recFnName := `_, baseSchedules := [], recSchedules := [], score := {}, alreadyExists := true }
+    memo.modify (·.insert key (.done trivialSched))
+    return {}
+
+  -- 3. Insert inProgress placeholder (cycle detection)
+  memo.modify (·.insert key .inProgress)
+
+  -- 4. Derive schedules for each constructor
+  let indInfo ← getConstInfoInduct key.inductiveName
+  let indTypeComponents ← getComponentsOfArrowType indInfo.type
+  let argTypes := indTypeComponents.pop
+  let argNames := (List.range argTypes.size).map (fun i => Name.mkSimple s!"arg_{i}")
+  let argNamesTypes := argNames.toArray.zip argTypes
+
+
+  let mut baseSchedules : List (Name × Schedule) := []
+  let mut recSchedules : List (Name × Schedule) := []
+  let mut allDeps : Array ScheduleDep := #[]
+
+  try
+    let results ← withLocalDeclsDND argNamesTypes fun _ => do
+      let mut localCtx ← getLCtx
+      let mut freshUnknowns := #[]
+      for argName in argNames do
+        let freshArgName := localCtx.getUnusedName argName
+        localCtx := localCtx.renameUserName argName freshArgName
+        freshUnknowns := freshUnknowns.push freshArgName
+
+      let freshenedInputNames := freshUnknowns.toList.filter
+        (fun n => key.outputIndices.all (fun idx => freshUnknowns.getD idx `_ != n))
+      let freshenedOutputNamesTypesIndices : List (Name × Expr × Nat) :=
+        key.outputIndices.map (fun idx => (freshUnknowns.getD idx `x, argTypes.getD idx (mkSort .zero), idx))
+      let freshRecFnName := localCtx.getUnusedName `aux_arb
+
+      let mut base : List (Name × Schedule) := []
+      let mut rec_ : List (Name × Schedule) := []
+      let mut deps : Array ScheduleDep := #[]
+
+      -- Per-constructor: derive schedule, collect deps, classify as base vs recursive
+      for ctorName in indInfo.ctors do
+        try
+          let scheduleOption ← (UnifyM.runInMetaM
+            (getProducerScheduleForInductiveConstructor key.inductiveName ctorName
+              freshenedOutputNamesTypesIndices freshenedInputNames freshUnknowns
+              key.deriveSort localCtx freshRecFnName)
+              emptyUnifyState)
+          match scheduleOption with
+          | some (scheduleSteps, scheduleSort) =>
+            let rewrittenSteps := scheduleRewriter scheduleSteps
+            let schedule := (rewrittenSteps, scheduleSort)
+            let ctorDeps := collectNonRecDeps rewrittenSteps
+            for dep in ctorDeps do
+              if !deps.contains dep then
+                deps := deps.push dep
+            let isRec ← isConstructorRecursive key.inductiveName ctorName
+            if isRec || scheduleUsesMutualCall rewrittenSteps then
+              rec_ := rec_ ++ [(ctorName, schedule)]
+            else
+              base := base ++ [(ctorName, schedule)]
+          | none => pure ()
+        catch _ => pure ()  -- skip constructors that fail to schedule
+      return (base, rec_, deps, freshUnknowns.toList, freshRecFnName)
+
+    -- Unpack results from the withLocalDeclsDND scope
+    let (base, rec_, deps, fNames, rFnName) := results
+    baseSchedules := base
+    recSchedules := rec_
+    allDeps := deps
+    -- 5. Recursively derive deps
+    for dep in deps do
+      if dep.kind == .relation then
+        let depKey : SpecKey := { inductiveName := dep.inductiveName, outputIndices := dep.outputIndices, deriveSort := dep.deriveSort }
+        let _ ← deriveBestInductiveSchedule depKey memo scheduleRewriter
+    -- 6. Store result
+    let score : SpecScore := { checks := 0, unconstrained := 0, backtracking := 0 }
+    let indSched : InductiveSchedule := {
+      key := key
+      argNames := fNames
+      recFnName := rFnName
+      baseSchedules := base
+      recSchedules := rec_
+      score := score
+    }
+    memo.modify (·.insert key (.done indSched))
+    return score
+  catch _ =>
+    memo.modify (·.insert key (.failed s!"Failed to derive schedules for {key.inductiveName}"))
+    return { unconstrained := 1 }
+
+/-- Derives schedules for a spec and returns the dependencies (Source.NonRec calls)
+    without compiling to code. Used by auto-derive to discover what instances are needed. -/
+def collectSpecDependencies
+  (_args : Array Expr) (outputVars : Array Expr) (outputTypes : Array Expr)
+  (constrainingInductive : Name) (_inductiveLevels : List Level)
+  (constrArgs : Array Expr) (deriveSort : DeriveSort)
+  (scheduleRewriter : List ScheduleStep → List ScheduleStep := id)
+  (recFnNameOverride : Option Name := none) :
+  TermElabM (Array ScheduleDep) := do
+
+  let inductiveName := constrainingInductive
+  let outputFVars := outputVars.map Expr.fvarId!
+  let mut outputIdxs : Array Nat := #[]
+  for i in [:constrArgs.size] do
+    let arg := constrArgs[i]!
+    if arg.isFVar && outputFVars.contains arg.fvarId! then
+      outputIdxs := outputIdxs.push i
+  if outputIdxs.isEmpty then
+    throwError m!"cannot find output indices"
+  let inductiveVal ← getConstInfoInduct inductiveName
+  let inductiveTypeComponents ← getComponentsOfArrowType inductiveVal.type
+  let argTypes := inductiveTypeComponents.pop
+  let argNames ← constrArgs.mapIdxM
+    (fun i (ident : Expr) =>
+      if ident.isFVar then ident.fvarId!.getUserName
+      else if let some outIdx := outputIdxs.findIdx? (· == i) then
+        outputVars[outIdx]!.fvarId!.getUserName
+      else throwError m!"{ident} is expected to be a variable.")
+    -- Freshen arg names, then derive schedule per constructor to collect deps
+  let argNamesTypes := argNames.zip argTypes
+  withLocalDeclsDND argNamesTypes (fun _ => do
+    let mut localCtx ← getLCtx
+    let mut freshUnknowns := #[]
+    for argName in argNames do
+      let freshArgName := localCtx.getUnusedName argName
+      localCtx := localCtx.renameUserName argName freshArgName
+      freshUnknowns := freshUnknowns.push freshArgName
+    let freshenedOutputNames := outputIdxs.map (fun idx => freshUnknowns[idx]!)
+    let freshenedInputNamesExcludingOutput := freshUnknowns.toList.filter
+      (fun n => freshenedOutputNames.toList.all (· != n))
+    let outputNamesTypesIndices : List (Name × Expr × Nat) :=
+      (List.range outputIdxs.size).map (fun i =>
+        (freshenedOutputNames[i]!, outputTypes[i]!, outputIdxs[i]!))
+    -- Accumulate all unique non-recursive deps across constructors
+    let freshRecFnName := recFnNameOverride.getD (localCtx.getUnusedName `aux_arb)
+    let mut allDeps : Array ScheduleDep := #[]
+    for ctorName in inductiveVal.ctors do
+      let scheduleOption ← (UnifyM.runInMetaM
+        (getProducerScheduleForInductiveConstructor inductiveName ctorName outputNamesTypesIndices
+          freshenedInputNamesExcludingOutput freshUnknowns deriveSort localCtx freshRecFnName)
+          emptyUnifyState)
+      match scheduleOption with
+      | some (scheduleSteps, _) =>
+        let rewrittenSteps := scheduleRewriter scheduleSteps
+        let deps := collectNonRecDeps rewrittenSteps
+        for dep in deps do
+          if !allDeps.contains dep then
+            allDeps := allDeps.push dep
+      | none => pure ()
+    return allDeps)
+
 /-- Like `deriveConstrainedProducer` but returns the components needed for assembly
     into either a standalone instance or a mutual def block.
     Returns: (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, inductiveName, inductiveLevels, producerSort) -/
@@ -837,9 +1148,12 @@ def deriveConstrainedProducerParts
         | some (scheduleSteps, scheduleSort) =>
           let rewrittenSteps := scheduleRewriter scheduleSteps
           let schedule := (rewrittenSteps, scheduleSort)
-          let (subProducer, _instances) ← StateT.run (s := #[]) (do
+          let (subProducer, requiredInsts) ← StateT.run (s := #[]) (do
             let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) _outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
             MExp.mexpToTSyntax mexp deriveSort)
+          if !requiredInsts.isEmpty then
+            let outputIdxsStr := outputNamesTypesIndices.map (fun (n, _, i) => s!"{n}@{i}")
+            trace[plausible.deriving.arbitrary] m!"[{repr deriveSort}] {inductiveName} (outputs: {outputIdxsStr}) constructor {ctorName} requires: {requiredInsts}"
           let isRecursive ← (isConstructorRecursive inductiveName ctorName) <||> pure (scheduleUsesMutualCall rewrittenSteps)
           if isRecursive then
             let subProducerTerm ← match producerSort with
@@ -1007,8 +1321,55 @@ a term describing the constraint. Entries in the same SCC are compiled into a sh
 
 /-- Command for deriving multiple constrained generators in sequence,
     each with multi-output hypothesis steps enabled.
-    Later entries can use instances derived by earlier ones. -/
-syntax (name := mutual_deriver) "derive_mutual" term,+ : command
+    Later entries can use instances derived by earlier ones.
+    Each entry can optionally be prefixed with a sort keyword (default: generator). -/
+syntax mutualEntry := ("generator" <|> "enumerator" <|> "checker")? term
+syntax (name := mutual_deriver) "derive_mutual" mutualEntry,+ : command
+
+/-- Derives a constrained producer instance directly from a ScheduleDep,
+    without going through syntax parsing. Returns the instance command. -/
+def deriveFromScheduleDep (dep : ScheduleDep) (scheduleRewriter : List ScheduleStep → List ScheduleStep := id)
+    (recFnNameOverride : Option Name := none) : TermElabM (TSyntax `command) := do
+  let indInfo ← getConstInfoInduct dep.inductiveName
+  let indLevels := indInfo.levelParams.map (Level.param ·)
+  let indTypeComponents ← getComponentsOfArrowType indInfo.type
+  let argTypes := indTypeComponents.pop
+  -- Create fvars for all args
+  let argNameTypes : Array (Name × Expr) := Id.run do
+    let mut result := #[]
+    let mut inpIdx := 0
+    let mut outIdx := 0
+    for i in [:argTypes.size] do
+      if i ∈ dep.outputIndices then
+        let name := Name.mkSimple s!"out_{outIdx}"
+        result := result.push (name, argTypes[i]!)
+        outIdx := outIdx + 1
+      else
+        let name := Name.mkSimple s!"inp_{inpIdx}"
+        result := result.push (name, argTypes[i]!)
+        inpIdx := inpIdx + 1
+    result
+  withLocalDeclsDND argNameTypes fun allFVars => do
+    let inputFVars := Id.run do
+      let mut result := #[]
+      for i in [:argTypes.size] do
+        if i ∉ dep.outputIndices then
+          result := result.push allFVars[i]!
+      result
+    let outputFVars := Id.run do
+      let mut result := #[]
+      for i in [:argTypes.size] do
+        if i ∈ dep.outputIndices then
+          result := result.push allFVars[i]!
+      result
+    let outputTypes := dep.outputIndices.filterMap (fun i => argTypes[i]?)
+    let deriveSort := dep.deriveSort
+    let parts ← deriveConstrainedProducerParts inputFVars outputFVars outputTypes.toArray
+      dep.inductiveName indLevels allFVars deriveSort scheduleRewriter recFnNameOverride
+    let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outTypes, localCtx, _, _, producerSort) := parts
+    mkConstrainedProducerTypeClassInstance baseProducers inductiveProducers
+      dep.inductiveName indLevels freshArgIdents freshenedOutputNames.toList
+      outTypes.toList producerSort localCtx
 
 @[command_elab mutual_deriver]
 def elabDeriveMutual : CommandElab := fun stx => do
@@ -1017,12 +1378,30 @@ def elabDeriveMutual : CommandElab := fun stx => do
     withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
       let specEntries := entries.getElems
 
-      -- Step 1: Parse all specs to get (inductiveName, outputIdxs) and assign global def names
-      let mut specMeta : Array (Name × List Nat × Name) := #[]
+      -- Step 1: Parse all specs to get (inductiveName, outputIdxs, deriveSort) and assign global def names
+      let mut specMeta : Array (Name × List Nat × Name × DeriveSort) := #[]
       for i in [:specEntries.size] do
         let entry := specEntries[i]!
+        -- Parse the optional sort keyword from the mutualEntry syntax
+        let (deriveSort, termStx) : DeriveSort × (TSyntax `term) := Id.run do
+          let children := entry.raw.getArgs
+          -- mutualEntry = ("generator" | "enumerator" | "checker")? term
+          -- If keyword present: children[0] is the keyword, children[1] is the term
+          -- If no keyword: children[0] is empty, children[1] is the term (or just the term)
+          if children.size >= 2 then
+            let kw := children[0]!
+            let tm := children[1]!
+            if kw.isOfKind `null && kw.getArgs.isEmpty then
+              (.Generator, ⟨tm⟩)
+            else
+              let sort := if kw.getArgs.any (fun a => a.isIdent && a.getId == `checker) then .Checker
+                else if kw.getArgs.any (fun a => a.isIdent && a.getId == `enumerator) then .Enumerator
+                else .Generator
+              (sort, ⟨tm⟩)
+          else
+            (.Generator, ⟨entry.raw⟩)
         let (indName, outIdxs) ← liftTermElabM do
-          let e ← elabTerm entry .none
+          let e ← elabTerm termStx .none
           lambdaTelescope e fun _args body => do
             peelExistentialsAux body #[] #[] fun innerBody outVars _outTypes => do
               innerBody.withApp fun ind indArgs => do
@@ -1034,40 +1413,105 @@ def elabDeriveMutual : CommandElab := fun stx => do
                   if indArgs[j]!.isFVar && outputFVars.contains indArgs[j]!.fvarId! then
                     idxs := idxs.push j
                 return (indName, idxs.toList)
-        let globalName := Name.mkSimple s!"specimen_mutual_{indName.toString.replace "." "_"}_{i}"
-        specMeta := specMeta.push (indName, outIdxs, globalName)
+        let uid ← liftTermElabM (Lean.Core.mkFreshUserName `specimen_mutual)
+        let globalName := Name.mkSimple s!"{uid}_{indName.toString.replace "." "_"}_{i}"
+        specMeta := specMeta.push (indName, outIdxs, globalName, deriveSort)
 
-      let siblings := specMeta.toList
-
-      -- Step 2: Derive each spec, collecting (def, instance) pairs.
-      -- Uses mkConstrainedProducerMutualPieces which emits a standalone `def` + thin `instance`.
-      let mut defCmds : Array (TSyntax `command) := #[]
-      let mut instCmds : Array (TSyntax `command) := #[]
-      for i in [:specEntries.size] do
-        let entry := specEntries[i]!
-        let (_, _, globalName) := specMeta[i]!
-        let rewriter := fun steps => rewriteMutualCalls steps siblings
-        let (defCmd, instCmd) ← liftTermElabM do
-          let e ← elabTerm entry .none
-          withParsedDerivingArgs e fun args outVars outTypes indName indLevels indArgs => do
-            let parts ← deriveConstrainedProducerParts args outVars outTypes indName indLevels indArgs .Generator rewriter globalName
-            let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, _, inductiveLevels, producerSort) := parts
-            mkConstrainedProducerMutualPieces baseProducers inductiveProducers
-              indName inductiveLevels freshArgIdents freshenedOutputNames
-              outputTypes producerSort localCtx globalName
-        defCmds := defCmds.push defCmd
-        instCmds := instCmds.push instCmd
-
-      -- Step 3: Emit a `mutual ... end` block with all defs, then instances
-      let mutualCmd ← `(command| mutual $defCmds* end)
-      let mutualFormat ← liftCoreM (PrettyPrinter.ppCommand mutualCmd)
-      liftTermElabM $ Tactic.TryThis.addSuggestion stx
-        (Format.pretty mutualFormat) (header := "Mutual block: ")
-      elabCommand mutualCmd
-
-      for instCmd in instCmds do
-        let genFormat ← liftCoreM (PrettyPrinter.ppCommand instCmd)
-        liftTermElabM $ Tactic.TryThis.addSuggestion stx
-          (Format.pretty genFormat) (header := "Try this instance: ")
-        elabCommand instCmd
+      -- Auto-derive: recursively discover and derive all transitive dependencies
+      -- Step 2: Derive schedules (auto-derive discovers transitive deps, or manual mode)
+      let autoDerive := Lean.Option.get (← getOptions) specimen.autoDeriveDeps
+      if autoDerive then
+        let memo ← IO.mkRef ({} : Std.HashMap SpecKey MemoEntry)
+        -- Recursively derive schedules for all user specs (populates memo with all deps)
+        for (indName, outIdxs, _, ds) in specMeta do
+          let key : SpecKey := { inductiveName := indName, outputIndices := outIdxs, deriveSort := ds }
+          let _ ← liftTermElabM <| deriveBestInductiveSchedule key memo
+        -- DFS from roots to find actually-used deps
+        let finalMemo ← memo.get
+        let mut usedKeys : Std.HashSet SpecKey := {}
+        for (indName, outIdxs, _, ds) in specMeta do
+          let key : SpecKey := { inductiveName := indName, outputIndices := outIdxs, deriveSort := ds }
+          usedKeys := collectUsedDeps key finalMemo usedKeys
+        -- Add all used deps to specMeta (so they're included in the mutual block)
+        for key in usedKeys.toList do
+          let inBlock := specMeta.any fun (sIndName, sOutIdxs, _, _) =>
+            sIndName == key.inductiveName && sOutIdxs == key.outputIndices
+          if !inBlock then
+            let uid ← liftTermElabM (Lean.Core.mkFreshUserName `specimen_mutual)
+            let globalName := Name.mkSimple s!"{uid}_{key.inductiveName.toString.replace "." "_"}_auto"
+            specMeta := specMeta.push (key.inductiveName, key.outputIndices, globalName, key.deriveSort)
+        -- Use SCC-based compilation from memo
+        -- Step 3: SCC decomposition and compilation
+        let components := computeSpecSCC usedKeys.toList finalMemo
+        logInfo m!"derive_mutual: {usedKeys.size} specs in {components.length} components"
+        -- For each component: assign names, compile, emit
+        for comp in components do
+          -- Assign global names for this component
+          let mut compMeta : Array (SpecKey × Name) := #[]
+          for key in comp do
+            let uid ← liftTermElabM (Lean.Core.mkFreshUserName `specimen_mutual)
+            let globalName := Name.mkSimple s!"{uid}_{key.inductiveName.toString.replace "." "_"}"
+            compMeta := compMeta.push (key, globalName)
+          -- Build siblings list for this component (for MutRec rewriting)
+          let compSiblings : List (Name × List Nat × Name × DeriveSort) :=
+            compMeta.toList.map (fun (k, gn) => (k.inductiveName, k.outputIndices, gn, k.deriveSort))
+          -- Compile each spec in the component
+          let mut defCmds : Array (TSyntax `command) := #[]
+          let mut instCmds : Array (TSyntax `command) := #[]
+          for (key, globalName) in compMeta do
+            match finalMemo[key]? with
+            | some (.done indSched) =>
+              if indSched.alreadyExists then continue
+              try
+                let (defCmd, instCmd) ← liftTermElabM <|
+                  compileInductiveSchedule indSched globalName compSiblings
+                defCmds := defCmds.push defCmd
+                instCmds := instCmds.push instCmd
+              catch e =>
+                logWarning m!"Failed to compile {key.inductiveName}{key.outputIndices}{repr key.deriveSort}: {e.toMessageData}"
+            | _ => logWarning m!"No schedule found for {key.inductiveName}{key.outputIndices}"
+          -- Emit: mutual block for multi-element, standalone for singletons
+          let specDescs ← compMeta.toList.mapM fun (k, _) => do
+            let numArgs ← liftTermElabM do
+              try
+                let comps ← getComponentsOfArrowType (← getConstInfoInduct k.inductiveName).type
+                pure (comps.size - 1)
+              catch _ => pure k.outputIndices.length
+            pure (k.prettyPrint numArgs)
+          if defCmds.size > 1 then
+            logInfo m!"  mutual block ({defCmds.size}):\n    {String.intercalate "\n    " specDescs}"
+            let mutualCmd ← `(command| mutual $defCmds* end)
+            elabCommand mutualCmd
+          else if defCmds.size == 1 then
+            logInfo m!"  singleton: {specDescs.head!}"
+            elabCommand defCmds[0]!
+          for instCmd in instCmds do
+            elabCommand instCmd
+      else
+        -- Fallback: no auto-derive, use old per-entry compilation
+        let siblings := specMeta.toList
+        let mut defCmds : Array (TSyntax `command) := #[]
+        let mut instCmds : Array (TSyntax `command) := #[]
+        for i in [:specEntries.size] do
+          let rawEntry := specEntries[i]!
+          -- Extract term from mutualEntry syntax (skip optional keyword)
+          let termStx : TSyntax `term := Id.run do
+            let children := rawEntry.raw.getArgs
+            if children.size >= 2 then ⟨children[1]!⟩ else ⟨rawEntry.raw⟩
+          let (_, _, globalName, _) := specMeta[i]!
+          let rewriter := fun steps => rewriteMutualCalls steps siblings
+          let (defCmd, instCmd) ← liftTermElabM do
+            let e ← elabTerm termStx .none
+            withParsedDerivingArgs e fun args outVars outTypes indName indLevels indArgs => do
+              let parts ← deriveConstrainedProducerParts args outVars outTypes indName indLevels indArgs .Generator rewriter (some globalName)
+              let (baseProducers, inductiveProducers, freshenedOutputNames, freshArgIdents, outputTypes, localCtx, _, inductiveLevels, producerSort) := parts
+              mkConstrainedProducerMutualPieces baseProducers inductiveProducers
+                indName inductiveLevels freshArgIdents freshenedOutputNames.toList
+                outputTypes.toList producerSort localCtx globalName .Generator
+          defCmds := defCmds.push defCmd
+          instCmds := instCmds.push instCmd
+        let mutualCmd ← `(command| mutual $defCmds* end)
+        elabCommand mutualCmd
+        for instCmd in instCmds do
+          elabCommand instCmd
   | _ => throwUnsupportedSyntax

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -123,6 +123,11 @@ structure ScheduleEnv where
       Currently only same-sort mutual calls are supported (gen↔gen, checker↔enum). -/
   mutualSiblings : List (Name × List Nat × Name × DeriveSort) := []
 
+  /-- Memoization for recursive dependency derivation.
+      When set, the step scorer uses this to recursively derive deps and cache results.
+      Keys that map to `inProgress` indicate a cycle (mutual recursion). -/
+  depMemo : Option (IO.Ref (Std.HashMap SpecKey MemoEntry)) := none
+
 /-- A monad for deriving generator schedules. Under the hood,
     `ScheduleM` is just a reader monad stacked on top of `MetaM`,
     with `ScheduleEnv` serving as the environment for the reader monad. -/
@@ -1287,7 +1292,7 @@ private def possiblePreSchedules (vars : List TypedVar) (hypotheses : List Hypot
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [] ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [], none ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1322,7 +1327,7 @@ private def possiblePreSchedulesWithAdvancedPruning (vars : List TypedVar) (hypo
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, multiOutput, [] ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, multiOutput, [], none ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckedHypotheses scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses
@@ -1364,7 +1369,7 @@ private def possibleSchedules' (ctorName : Name) (vars : List TypedVar) (hypothe
   let sortedHypotheses := mkSortedHypothesesVariablesMap hypotheses
   let varNames := vars.map (fun x => x.var)
   let prodSort := convertDeriveSortToProducerSort deriveSort
-  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [] ⟩
+  let scheduleEnv := ⟨ vars, sortedHypotheses, deriveSort, prodSort, recCall, fixedVars, recFnName, false, [], none ⟩
   let remainingVars := List.filter (fun v => not <| fixedVars.contains v) varNames
   let (newCheckedIdxs, newCheckedHyps) := List.unzip <| (collectCheckSteps scheduleEnv fixedVars [])
   let remainingSortedHypotheses := filterWithIndex (fun i _ => i ∉ newCheckedIdxs) sortedHypotheses

--- a/Specimen/MakeConstrainedProducerInstance.lean
+++ b/Specimen/MakeConstrainedProducerInstance.lean
@@ -223,9 +223,10 @@ def mkConstrainedProducerTypeClassInstance
 def mkConstrainedProducerMutualPieces
   (baseGenerators : TSyntax `term) (inductiveGenerators : TSyntax `term)
   (inductiveName : Name) (inductiveLevels : List Level)
-  (args : TSyntaxArray `term) (targetVars : Array Name)
-  (targetTypes : Array Expr) (producerSort : ProducerSort)
-  (topLevelLocalCtx : LocalContext) (globalDefName : Name) :
+  (args : TSyntaxArray `term) (targetVars : List Name)
+  (targetTypes : List Expr) (producerSort : ProducerSort)
+  (topLevelLocalCtx : LocalContext) (globalDefName : Name)
+  (deriveSort : DeriveSort) :
   TermElabM (TSyntax `command × TSyntax `command) := do
     -- Reuse the same computation as mkConstrainedProducerTypeClassInstance
     let freshSizeIdent := mkFreshAccessibleIdent topLevelLocalCtx `size
@@ -247,7 +248,7 @@ def mkConstrainedProducerMutualPieces
     let matchExpr ← mkMatchExpr fuelIdent fuelCaseExprs
 
     let paramInfo ← analyzeInductiveArgs inductiveName inductiveLevels args
-    let targetVarsList := targetVars.toList
+    let targetVarsList := targetVars
 
     -- Build the function type: Nat → Nat → Nat → param types → Gen α
     let mut paramTypes : Array (TSyntax `term) := #[natIdent, natIdent, natIdent]
@@ -276,23 +277,24 @@ def mkConstrainedProducerMutualPieces
     let targetTypeSyntax ← do
       let syns ← if outputTypeSyntaxes.isEmpty then
         targetTypes.mapM (fun ty => PrettyPrinter.delab ty)
-      else pure outputTypeSyntaxes
+      else pure outputTypeSyntaxes.toList
       let rec mkProdType : List (TSyntax `term) → TermElabM (TSyntax `term)
         | [] => throwError "no output types found"
         | [t] => pure t
         | t :: ts => do let rest ← mkProdType ts; `($t × $rest)
-      mkProdType syns.toList
+      mkProdType syns
 
     let targetVarPattern : TSyntax `term ← do
       let rec mkProdPat : List Name → TermElabM (TSyntax `term)
         | [] => throwError "no output variables"
         | [v] => `($(Lean.mkIdent v))
         | v :: vs => do let rest ← mkProdPat vs; `(($(Lean.mkIdent v), $rest))
-      mkProdPat targetVars.toList
+      mkProdPat targetVars
 
-    let optionTProducerType ← match producerSort with
+    let optionTProducerType ← match deriveSort with
       | .Generator => `($genTypeConstructor $targetTypeSyntax)
       | .Enumerator => `($exceptTTypeConstructor $genErrorType $enumTypeConstructor $targetTypeSyntax)
+      | .Checker | .Theorem => `($exceptTypeConstructor $genErrorType $boolIdent)
 
     -- Build the full function type for the def
     let mut fullType ← pure optionTProducerType
@@ -306,24 +308,31 @@ def mkConstrainedProducerMutualPieces
     let defIdent := mkIdent globalDefName
     let defCmd ← `(command| def $defIdent : $fullType := $lambdaBody)
 
-    -- Emit the instance
-    let producerTypeClass := match producerSort with
-      | .Generator => arbitrarySizedSuchThatTypeclass
-      | .Enumerator => enumSizedSuchThatTypeclass
-    let producerTypeClassFunction := match producerSort with
-      | .Generator => unqualifiedArbitrarySizedSTFn
-      | .Enumerator => unqualifiedEnumSizedSTFn
-    let producerUnconstrainedClass := match producerSort with
-      | .Generator => ``Plausible.Arbitrary
-      | .Enumerator => ``Enum
-    let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
+    -- Emit the instance (differs by deriveSort)
     let fuelVal := Lean.Option.get (← getOptions) specimen.fuel
     let fuelLit := Syntax.mkNumLit (toString fuelVal)
     let callArgs : TSyntaxArray `term := #[(⟨fuelLit⟩ : TSyntax `term), (freshSizeIdent : TSyntax `term), (freshSizeIdent : TSyntax `term)] ++ (TSyntaxArray.mk outerParams)
     let callExpr ← `($defIdent $callArgs*)
-    let instCmd ← `(command|
-      instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
-        $producerTypeClassFunction:ident := fun $freshSizeIdent => $callExpr)
+    let instCmd ← match deriveSort with
+      | .Checker | .Theorem => do
+        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Enum, ``DecidableEq]
+        `(command|
+          instance $arbitraryTypeParamInstances:bracketedBinder* : $decOptTypeclass (@$(mkIdent inductiveName) $args*) where
+            $unqualifiedDecOptFn:ident := fun $freshSizeIdent => $callExpr)
+      | _ => do
+        let producerTypeClass := match producerSort with
+          | .Generator => arbitrarySizedSuchThatTypeclass
+          | .Enumerator => enumSizedSuchThatTypeclass
+        let producerTypeClassFunction := match producerSort with
+          | .Generator => unqualifiedArbitrarySizedSTFn
+          | .Enumerator => unqualifiedEnumSizedSTFn
+        let producerUnconstrainedClass := match producerSort with
+          | .Generator => ``Plausible.Arbitrary
+          | .Enumerator => ``Enum
+        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
+        `(command|
+          instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
+            $producerTypeClassFunction:ident := fun $freshSizeIdent => $callExpr)
 
     return (defCmd, instCmd)
 

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -48,7 +48,7 @@ inductive DeriveSort
   | Enumerator
   | Checker
   | Theorem
-  deriving Repr, BEq, Ord
+  deriving Repr, BEq, Ord, Hashable, Inhabited
 
 /-- Determines if a `DeriveSort` corresponds to a producer
     (only generators & enumerators are considered producers) -/
@@ -269,41 +269,219 @@ def addConclusionPatternsAndEqualitiesToSchedule (patterns : List (Unknown × Pa
   let equalityCheckSteps := (fun (u1, u2) => ScheduleStep.Check (Source.NonRec (``Eq, [.Unknown u1, .Unknown u2])) true) <$> equalities.toList
   (matchSteps ++ equalityCheckSteps ++ existingScheduleSteps, scheduleSort)
 
+/-- Extracts all variable names from a ConstructorExpr (looks inside constructors) -/
+partial def varsInConstructorExpr : ConstructorExpr → List Name
+  | .Unknown u => [u]
+  | .Ctor _ args | .FuncApp _ args | .TyCtor _ args => args.flatMap varsInConstructorExpr
+  | .Lit _ | .CSort _ => []
+
+/-- Computes output indices: position i is an output if any output variable appears in it -/
+def computeOutputIndicesForRewrite (hypArgs : List ConstructorExpr) (outputVarNames : List Name) : List Nat :=
+  filterMapWithIndex (fun i arg =>
+    let vars := varsInConstructorExpr arg
+    if vars.any (· ∈ outputVarNames) then some i else none) hypArgs
+
 /-- Rewrites `Source.NonRec` calls in schedule steps to `Source.MutRec` when the hypothesis
-    matches a sibling spec exactly (same inductive name AND same number of output variables).
-    `siblings` is `(inductiveName, outputIndices, auxFnName)`. -/
-def rewriteMutualCalls (steps : List ScheduleStep) (siblings : List (Name × List Nat × Name)) : List ScheduleStep :=
-  let matchesSibling (hyp : HypothesisExpr) (numOutputs : Nat) : Option (Name × List Nat) :=
+    matches a sibling spec exactly (same inductive, same output positions, same derive sort).
+    `siblings` is `(inductiveName, outputIndices, auxFnName, siblingDeriveSort)`. -/
+def rewriteMutualCalls (steps : List ScheduleStep) (siblings : List (Name × List Nat × Name × DeriveSort)) : List ScheduleStep :=
+  let matchesSibling (hyp : HypothesisExpr) (outNames : List Name) (stepDeriveSort : DeriveSort) : Option (Name × List Nat) :=
     let (hypName, hypArgs) := hyp
-    let numInputs := hypArgs.length - numOutputs
-    siblings.findSome? fun (indName, outputIdxs, auxName) =>
-      if hypName == indName && outputIdxs.length == numOutputs && (hypArgs.length - outputIdxs.length) == numInputs then
-        some (auxName, outputIdxs)
+    let stepOutputIdxs := computeOutputIndicesForRewrite hypArgs outNames
+    siblings.findSome? fun (indName, sibOutputIdxs, auxName, sibSort) =>
+      if hypName == indName && stepOutputIdxs == sibOutputIdxs && stepDeriveSort == sibSort then
+        some (auxName, sibOutputIdxs)
       else none
   steps.map fun step =>
     match step with
     | .SuchThat vs (.NonRec hyp) ps =>
-      match matchesSibling hyp vs.length with
+      let ds := match ps with | .Generator => DeriveSort.Generator | .Enumerator => .Enumerator
+      match matchesSibling hyp (vs.map Prod.fst) ds with
       | some (auxName, outputIdxs) =>
         let (_, hypArgs) := hyp
         let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
         .SuchThat vs (.MutRec auxName inputArgs) ps
       | none => step
     | .Unconstrained v (.NonRec hyp) ps =>
-      match matchesSibling hyp 1 with
+      let ds := match ps with | .Generator => DeriveSort.Generator | .Enumerator => .Enumerator
+      match matchesSibling hyp [v] ds with
       | some (auxName, outputIdxs) =>
         let (_, hypArgs) := hyp
         let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
         .Unconstrained v (.MutRec auxName inputArgs) ps
       | none => step
     | .Check (.NonRec hyp) pol =>
-      match matchesSibling hyp 0 with
-      | some (auxName, outputIdxs) =>
+      match matchesSibling hyp [] .Checker with
+      | some (auxName, _) =>
         let (_, hypArgs) := hyp
-        let inputArgs := filterWithIndex (fun i _ => i ∉ outputIdxs) hypArgs
-        .Check (.MutRec auxName inputArgs) pol
+        .Check (.MutRec auxName hypArgs) pol
       | none => step
     | other => other
+
+/-- Identifies a unique derivation spec (inductive + output mode + sort). -/
+structure SpecKey where
+  inductiveName : Name
+  outputIndices : List Nat
+  deriveSort : DeriveSort
+  deriving Repr, BEq, Hashable
+
+/-- Pretty-prints a SpecKey as a spec form like "fun τ => ∃ Γ e, typing Γ e τ".
+    Requires knowing the inductive's arg types (number of args). -/
+def SpecKey.prettyPrint (key : SpecKey) (numArgs : Nat) : String :=
+  let inputVarNames := #["a", "b", "c", "d", "e", "f", "g", "h"]
+  let outputVarNames := #["x", "y", "z", "w", "u", "v", "p", "q"]
+  let (inputs, outputs, appArgs) := Id.run do
+    let mut inputs : List String := []
+    let mut outputs : List String := []
+    let mut appArgs : List String := []
+    let mut inpIdx := 0
+    let mut outIdx := 0
+    for i in List.range numArgs do
+      if i ∈ key.outputIndices then
+        let name := outputVarNames.getD outIdx s!"o{outIdx}"
+        outputs := outputs ++ [name]
+        appArgs := appArgs ++ [name]
+        outIdx := outIdx + 1
+      else
+        let name := inputVarNames.getD inpIdx s!"i{inpIdx}"
+        inputs := inputs ++ [name]
+        appArgs := appArgs ++ [name]
+        inpIdx := inpIdx + 1
+    (inputs, outputs, appArgs)
+  let inputsStr := if inputs.isEmpty then "" else s!"fun {String.intercalate " " inputs} => "
+  let outputsStr := if outputs.isEmpty then "" else s!"∃ {String.intercalate " " outputs}, "
+  s!"{inputsStr}{outputsStr}{key.inductiveName} {String.intercalate " " appArgs}"
+
+/-- Score for a derived schedule (used for selecting best schedule). -/
+structure SpecScore where
+  checks : Nat := 0
+  unconstrained : Nat := 0
+  backtracking : Nat := 0
+  deriving Repr, BEq, Ord
+
+instance : Inhabited SpecScore := ⟨{}⟩
+
+/-- A complete derivation plan for one inductive at one output mode.
+    Analogous to QuickChick's `inductive_schedule`. -/
+structure InductiveSchedule where
+  /-- The spec this schedule is for -/
+  key : SpecKey
+  /-- Freshened argument names (used in the schedule steps) -/
+  argNames : List Name
+  /-- The recursive function name used in Source.Rec calls -/
+  recFnName : Name
+  /-- Per-constructor schedules for non-recursive (base) constructors -/
+  baseSchedules : List (Name × Schedule)
+  /-- Per-constructor schedules for recursive constructors -/
+  recSchedules : List (Name × Schedule)
+  /-- Quality score for this derivation -/
+  score : SpecScore
+  /-- True if this spec already has an instance in the environment (no need to compile) -/
+  alreadyExists : Bool := false
+  deriving Repr
+
+/-- Result of deriving a schedule, stored in the dependency memo. -/
+inductive MemoEntry
+  | inProgress  -- derivation started, cycle detection
+  | done (indSched : InductiveSchedule)
+  | failed (msg : String)
+  deriving Repr
+
+/-- Whether a dependency is for a base type (needs Arbitrary/Enum) or a relation
+    (needs ArbitrarySizedSuchThat/EnumSizedSuchThat/DecOpt). -/
+inductive DepKind
+  /-- Unconstrained generation of a base type (needs `Arbitrary` or `Enum`) -/
+  | baseType
+  /-- Constrained generation from a relation (needs `ArbitrarySizedSuchThat` or `EnumSizedSuchThat`) -/
+  | relation
+  /-- Checking a relation (needs `DecOpt`) -/
+  | checker
+  deriving Repr, BEq
+
+/-- A dependency extracted from a schedule: what instance is needed.
+    - `kind`: whether this is a base type, constrained relation, or checker
+    - `inductiveName`: the type/relation being referenced
+    - `hypothesis`: the full hypothesis expression (indName + args)
+    - `outputVarNames`: the variables being produced (determines output positions)
+    - `outputIndices`: positions in the hypothesis args that are outputs
+    - `deriveSort`: the producer sort context (Generator or Enumerator) -/
+structure ScheduleDep where
+  kind : DepKind
+  inductiveName : Name
+  hypothesis : HypothesisExpr
+  outputVarNames : List Name
+  outputIndices : List Nat
+  deriveSort : DeriveSort
+  deriving Repr, BEq
+
+/-- Computes output indices: which positions in hypArgs are output variables -/
+private def computeOutputIndices (hypArgs : List ConstructorExpr) (outputVarNames : List Name) : List Nat :=
+  filterMapWithIndex (fun i arg =>
+    match arg with
+    | .Unknown name => if name ∈ outputVarNames then some i else none
+    | _ => none) hypArgs
+
+/-- Extracts all `Source.NonRec` dependencies from schedule steps.
+    Each dependency tells us what instance is needed: which inductive,
+    which argument positions are outputs, and what derive sort. -/
+def collectNonRecDeps (steps : List ScheduleStep) : List ScheduleDep :=
+  steps.filterMap fun step =>
+    match step with
+    | .SuchThat vs (.NonRec hyp) ps =>
+      let ds := match ps with | .Generator => DeriveSort.Generator | .Enumerator => .Enumerator
+      let outNames := vs.map Prod.fst
+      some { kind := .relation
+             inductiveName := hyp.fst
+             hypothesis := hyp
+             outputVarNames := outNames
+             outputIndices := computeOutputIndices hyp.snd outNames
+             deriveSort := ds }
+    | .Unconstrained v (.NonRec hyp) ps =>
+      let ds := match ps with | .Generator => DeriveSort.Generator | .Enumerator => .Enumerator
+      some { kind := .baseType
+             inductiveName := hyp.fst
+             hypothesis := hyp
+             outputVarNames := [v]
+             outputIndices := computeOutputIndices hyp.snd [v]
+             deriveSort := ds }
+    | .Check (.NonRec hyp) _ =>
+      some { kind := .checker
+             inductiveName := hyp.fst
+             hypothesis := hyp
+             outputVarNames := []
+             outputIndices := []
+             deriveSort := .Checker }
+    | _ => none
+
+/-- DFS from a root SpecKey through chosen schedules to find all actually-used dependencies. -/
+partial def collectUsedDeps (root : SpecKey) (memo : Std.HashMap SpecKey MemoEntry)
+    (visited : Std.HashSet SpecKey := {}) : Std.HashSet SpecKey :=
+  if visited.contains root then visited
+  else
+    let visited := visited.insert root
+    match memo[root]? with
+    | some (.done indSched) =>
+      let allSchedules := indSched.baseSchedules ++ indSched.recSchedules
+      let deps := allSchedules.flatMap (fun (_, (steps, _)) => collectNonRecDeps steps)
+      let relDeps := deps.filter (·.kind == .relation)
+      relDeps.foldl (fun acc dep =>
+        let depKey : SpecKey := { inductiveName := dep.inductiveName, outputIndices := dep.outputIndices, deriveSort := dep.deriveSort }
+        collectUsedDeps depKey memo acc) visited
+    | _ => visited
+
+/-- Given a set of used SpecKeys and the memo, compute SCCs (mutual groups).
+    Returns components in topological order (dependencies before dependants). -/
+def computeSpecSCC (usedKeys : List SpecKey) (memo : Std.HashMap SpecKey MemoEntry) : List (List SpecKey) :=
+  let successors (key : SpecKey) : List SpecKey :=
+    match memo[key]? with
+    | some (.done indSched) =>
+      let allScheds := indSched.baseSchedules ++ indSched.recSchedules
+      let deps := allScheds.flatMap (fun (_, (steps, _)) => collectNonRecDeps steps)
+      let relDeps := deps.filter (·.kind == .relation)
+      let depKeys := relDeps.map (fun d => SpecKey.mk d.inductiveName d.outputIndices d.deriveSort)
+      depKeys.filter (usedKeys.contains ·)
+    | _ => []
+  Lean.SCC.scc usedKeys successors
 
 /-- Checks if any step in a schedule uses `Source.MutRec`. -/
 def scheduleUsesMutualCall (steps : List ScheduleStep) : Bool :=

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputSTLCTest.lean
@@ -5,34 +5,24 @@ import SpecimenTest.DeriveArbitrary.DeriveSTLCTermTypeGenerators
 import SpecimenTest.DeriveDecOpt.DeriveSTLCChecker
 import SpecimenTest.DeriveArbitrarySuchThat.DeriveSTLCGenerator
 
-/-! Test: mutual multi-output constrained generation for STLC.
+/-! Test: auto-derive dependency discovery for STLC.
 
-    Uses derive_mutual to derive all input/output splits of `typing` and `lookup`
-    simultaneously. The mutual block handles circular dependencies between
-    "all outputs" typing (needs "τ fixed" for TAdd) and
-    "τ fixed" typing (needs "all outputs" for TApp). -/
+    With `specimen.autoDeriveDeps true`, derive_mutual discovers that typing
+    depends on lookup instances even when they're not explicitly listed. -/
 
 open Plausible
 
 set_option guard_msgs.diff true
 
--- Derive all mutual dependencies together
+-- Auto-derives missing lookup and typing sub-instances from a single top-level spec.
 #guard_msgs(drop info) in
+set_option specimen.autoDeriveDeps true in
 derive_mutual
-  (∃ (Γ : List type) (x : Nat) (τ : type), lookup Γ x τ),
-  (fun τ => ∃ (Γ : List type) (x : Nat), lookup Γ x τ),
-  (∃ (Γ : List type) (e : term) (τ : type), typing Γ e τ),
-  (fun τ => ∃ (Γ : List type) (e : term), typing Γ e τ)
+  (∃ (Γ : List type) (e : term) (τ : type), typing Γ e τ)
 
--- Verify instances
+-- Sample: generate a valid (context, index) pair for a fixed type
 #guard_msgs(drop info) in
-#check (inferInstance : ArbitrarySizedSuchThat (List type × term × type) (fun (Γ, e, τ) => typing Γ e τ))
-
-#guard_msgs(drop info) in
-#check (inferInstance : ArbitrarySizedSuchThat (List type × term) (fun (Γ, e) => typing Γ e .Nat))
-
--- Sample: generate a well-typed term with its context and type
 #eval! do
   let sample ← Gen.run
-    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : List type × term × type) => let (Γ, e, τ) := p; typing Γ e τ) 3) 10
+    (ArbitrarySizedSuchThat.arbitrarySizedST (fun (p : List type × Nat) => lookup p.1 p.2 (.Fun (.Fun .Nat .Nat) .Nat)) 2) 2
   return repr sample


### PR DESCRIPTION
## Summary

Adds automatic transitive dependency discovery to `derive_mutual`, so users only need to specify the top-level spec and all required sub-instances are discovered and derived automatically. Also adds checker and enumerator derivation support via per-entry sort keywords.

### Auto-derive (`set_option specimen.autoDeriveDeps true`)

- **`deriveBestInductiveSchedule`** — recursive memoized schedule derivation that traverses the dependency graph depth-first, deriving schedules for each relation encountered
- **`ScheduleDep` type + `collectNonRecDeps`** — analyzes schedule steps to extract all relation and base-type dependencies
- **`collectSpecDependencies`** — extracts all dependencies from a set of schedules, distinguishing relations (need derivation) from base types (need `Arbitrary`/`Enum` instances)
- **Instance existence checking** — uses `synthInstance` with proper universe handling (`Level.succ mkFreshLevelMVar`) to detect pre-existing instances and skip re-derivation
- **`alreadyExists` flag** — marks specs that already have instances, skipping compilation
- **Sort-typed position filtering** — filters `Sort`-typed positions from output indices (type parameters handled by instance binders, not generated)
- **Pretty-printed `SpecKey` display** — human-readable `fun a => ∃ x y, R a x y` format for logging

### Checker/enumerator derivation in `derive_mutual`

- **Per-entry sort keyword**: `derive_mutual generator (...), checker (...)` — default is `generator`
- **`compileInductiveSchedule`** emits `DecOpt` instances for checker specs
- **`mkConstrainedProducerMutualPieces`** handles all three derive sorts (generator, enumerator, checker)
- **`rewriteMutualCalls`** checks `DeriveSort` equality and output positions for correct sibling matching

### Usage

```lean
set_option specimen.autoDeriveDeps true in
set_option specimen.multiOutput true in
derive_mutual
  (fun Γ τ => ∃ e, typing Γ e τ)
-- Auto-discovers and derives: lookup, typing[multi-output], etc.
```

### Depends on

- #4 (multi-output support)
- #5 (derive_mutual core)

## Test plan

- [x] `MultiOutputSTLCTest.lean` — auto-derive discovers `lookup` as dep of `typing`
- [x] Cedar checker+generator tests pass (existing individual `derive_checker`/`derive_generator` calls)
- [x] All 116 existing test jobs pass without regression

---
*PR 3 of 5 (stacked): multi-output → derive_mutual → **auto-derive** → fixes → HTML infoview*