### PR TITLE
Add specimen.silent option to suppress `Try this:` suggestions

### DIFF
--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -28,6 +28,22 @@ register_option specimen.autoDeriveDeps : Bool := {
   descr := "automatically derive dependency instances in derive_mutual"
 }
 
+/-- Option to suppress Specimen's `Try this:` suggestion popups for
+    derived checkers/generators/enumerators. When `true`,
+    `derive_checker` / `derive_generator` / `derive_enumerator` silently
+    install the typeclass instance without pretty-printing the
+    expansion. Useful in build configurations where the suggestion text
+    floods the console. -/
+register_option specimen.silent : Bool := {
+  defValue := false
+  descr := "suppress `Try this:` suggestion output from derive_checker/derive_generator/derive_enumerator"
+}
+
+/-- Determines whether `specimen.silent` is set. -/
+def inSilentMode [Monad m] [MonadOptions m] : m Bool := do
+  let opts ← getOptions
+  return Lean.Option.get opts specimen.silent
+
 
 /-- Global flag for enabling/disabling debug messages -/
 def globalDebugFlag : Bool := false

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -1,5 +1,6 @@
 import Lean
 
+import Specimen.Debug
 import Specimen.MakeConstrainedProducerInstance
 import Specimen.DeriveConstrainedProducer
 import Specimen.Idents
@@ -252,9 +253,11 @@ def elabDeriveScheduledChecker : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeclassInstance)
 
     -- Display the code for the derived checker to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this checker: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this checker: ")
 
     -- Elaborate the typeclass instance and add it to the local context
     elabCommand typeclassInstance

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1326,9 +1326,11 @@ def elabDeriveGenerator : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
 
     -- Display the code for the derived generator to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this generator: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this generator: ")
 
     elabCommand typeClassInstance
 
@@ -1346,8 +1348,9 @@ def elabDeriveGeneratorMulti : CommandElab := fun stx => do
     withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
       let typeClassInstance ← liftTermElabM <| deriveArbitrarySuchThatInstance descr
       let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
-      liftTermElabM $ Tactic.TryThis.addSuggestion stx
-        (Format.pretty genFormat) (header := "Try this generator: ")
+      unless (← inSilentMode) do
+        liftTermElabM $ Tactic.TryThis.addSuggestion stx
+          (Format.pretty genFormat) (header := "Try this generator: ")
       elabCommand typeClassInstance
   | _ => throwUnsupportedSyntax
 
@@ -1367,9 +1370,11 @@ def elabDeriveScheduledEnumerator : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
 
     -- Display the code for the derived enumerator to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this enumerator: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this enumerator: ")
 
     elabCommand typeClassInstance
 


### PR DESCRIPTION
## Summary
Add `specimen.silent` (default `false`) to suppress the `Tactic.TryThis.addSuggestion` calls in `derive_checker`, `derive_generator`, `derive_generator_multi`, and `derive_enumerator`.

Each suggestion pretty-prints the entire derived term. Useful interactively (the VS Code side panel offers an "accept" button), but in batch builds with hundreds of derives the suggestion text floods stdout — a single Waimea build emits tens of thousands of lines that have no information value to the user.

When `specimen.silent` is `true`, the elaborators install the typeclass instance via `elabCommand` exactly as before but skip the `addSuggestion` call. Use as:

```lean
set_option specimen.silent true
```

Default behavior is unchanged.

## Test plan
- [x] `lake build` clean.
- [x] `set_option specimen.silent true` followed by `derive_checker` / `derive_generator` produces no `Try this:` output but still installs the instance (verified by `#check` on the synthesized DecOpt instance).
- [x] Default (`silent = false`) still emits suggestions.