### PR TITLE
MExp: omit wildcard arm for single-constructor match (fixes #12)

### DIFF
--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -450,8 +450,31 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
 
     -- TODO: double check if this is right
     pure $ .MBind .Checker checker [] k
-  | .Match explicit scrutinee pattern =>
-    pure $ .MMatch explicit (.MId scrutinee) [(pattern, k), (wildCardPattern, .MFail)]
+  | .Match explicit scrutinee pattern => do
+    -- If the scrutinee's type has only one constructor, the wildcard
+    -- fallthrough `| _ => MFail` is structurally redundant and Lean's
+    -- exhaustiveness check rejects it as a hard error
+    -- (`error(lean.redundantMatchAlt): Redundant alternative`). Look up
+    -- the constructor named in the pattern, find its inductive parent,
+    -- count siblings, and emit a single-arm match when there's only one.
+    let ctorName? : Option Name := match pattern with
+      | .CtorPattern n _ => some n
+      | _ => none
+    let isSingleCtor : Bool ← do
+      match ctorName? with
+      | none => pure false
+      | some cn =>
+        let env ← getEnv
+        match env.find? cn with
+        | some (.ctorInfo ci) =>
+          match env.find? ci.induct with
+          | some (.inductInfo ii) => pure (ii.ctors.length == 1)
+          | _ => pure false
+        | _ => pure false
+    let cases :=
+      if isSingleCtor then [(pattern, k)]
+      else [(pattern, k), (wildCardPattern, .MFail)]
+    pure $ .MMatch explicit (.MId scrutinee) cases
 
 /-- Converts a `Schedule` (a list of `ScheduleStep`s along with a `ScheduleSort`,
     which acts as the conclusion of the schedule) to an `MExp`.


### PR DESCRIPTION
## Summary
Fixes #12.

When `scheduleStepToMExp` lowers a `.Match` step it always emits

```lean
match scrutinee with
| <pattern>     => k
| _             => MFail
```

Lean's exhaustiveness check rejects the wildcard as `redundantMatchAlt` whenever the scrutinee's type has only one constructor — there are no other branches the wildcard could ever match. This blocks `derive_checker` / `derive_generator` whenever the clause destructures a single-constructor record (the most common case in practice: every assertion-derived relation written against an ISA's record-shaped instruction variant).

This PR detects the single-ctor case by looking up the constructor name in the pattern, finding its parent inductive, and counting siblings — emitting a single-arm match when there's only one. Multi-ctor scrutinees keep the existing two-arm form so a non-matching value still falls through to `MFail` and short-circuits the schedule.

## Repro

Before this PR:

```lean
import Specimen.DeriveChecker
import Specimen.DecOpt
import Plausible

structure S where
  a : UInt8
  b : UInt8
deriving Plausible.Arbitrary

inductive R : S → Prop where
| mk : x = 1 → R ⟨x, b⟩

derive_checker (fun s => R s)
-- error: redundantMatchAlt
```

After this PR: builds clean and the synthesized match is

```lean
match s_1 with
| S.mk x b => @DecOpt.decOpt (Eq UInt8 x 1) _ initSize
```

(no wildcard arm — Lean accepts it.)

## Test plan
- [x] Repro above compiles.
- [x] Multi-ctor regression: a relation matched against an `inductive E | A | B | C` still emits the wildcard arm and works as before.
- [x] `lake build` clean on the full Specimen tree.
- [x] Verified end-to-end against the Waimea downstream consumer: 8 leaf checkers + 3 single-conjunct composite checkers/generators that previously needed hand-curated workarounds now derive cleanly.