### PR TITLE
Add checker base-case failsafe for soundness

### DIFF
--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -198,7 +198,16 @@ def deriveScheduledChecker' (_args : Array Expr)
 
       -- Collect all the base / inductive checkers into two Lean list terms
       -- Base checkers are invoked when `size = 0`, inductive checkers are invoked when `size > 0`
-      let baseCheckers ← `([$nonRecursiveCheckers,*])
+      -- For checkers with recursive constructors, add a failsafe to the base case:
+      -- if no base constructor matches, return "unknown" (error) rather than "false",
+      -- since a recursive constructor might succeed at a larger size.
+      let baseCheckersWithFailsafe ← do
+        if !recursiveCheckers.isEmpty then
+          let failsafe ← `((fun (_ : $(Lean.mkIdent ``Unit)) => $failFn $genericFailure))
+          pure (nonRecursiveCheckers.push failsafe)
+        else
+          pure nonRecursiveCheckers
+      let baseCheckers ← `([$baseCheckersWithFailsafe,*])
       let inductiveCheckers ← `([$nonRecursiveCheckers,*, $recursiveCheckers,*])
 
       return (baseCheckers, inductiveCheckers, Lean.mkIdent <$> freshUnknowns, localCtx))

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -843,7 +843,16 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         | .Enumerator => pure subProducer
         | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
       recursiveProducers := recursiveProducers.push term
-    let baseProducers ← `([$nonRecursiveProducers,*])
+    -- For checkers with recursive constructors, add a failsafe to the base case:
+    -- if no base constructor matches, return "unknown" (error) rather than "false",
+    -- since a recursive constructor might succeed at a larger size.
+    let baseProducersWithFailsafe ← do
+      if (key.deriveSort == .Checker || key.deriveSort == .Theorem) && !recursiveProducers.isEmpty then
+        let failsafe ← `((fun (_ : Unit) => $failFn $genericFailure))
+        pure (nonRecursiveProducers.push failsafe)
+      else
+        pure nonRecursiveProducers
+    let baseProducers ← `([$baseProducersWithFailsafe,*])
     let allProducers := nonRecursiveProducers ++ recursiveProducers
     let inductiveProducers ← `([$allProducers,*])
     let argNames := (List.range allFVars.size).map (fun i => indSched.argNames.getD i (Name.mkSimple s!"arg_{i}"))


### PR DESCRIPTION
## Summary

- When a checker has recursive constructors, the `size=0` base case could incorrectly return `ok false` when no base constructor matches. This is unsound because a recursive constructor might succeed at a larger size.
- Following QuickChick's approach, we now append a failsafe entry to the base-case checker list that always throws an error. This causes `checkerBacktrack` to return "unknown" (error) instead of incorrectly concluding "false".
- Applied in both `DeriveChecker.lean` (the `derive_checker` command) and `compileInductiveSchedule` in `DeriveConstrainedProducer.lean` (the `derive_mutual` path for checkers).

## Test plan
- [x] `lake build` passes
- [x] `lake build SpecimenTest` passes (all 129 jobs)