### PR TITLE
Silence two unused-variable lints in elabDeriveMutual

### DIFF
--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1559,7 +1559,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
         let srcStyle := json% {"color": "#dcdcaa", "fontWeight": "bold"}
         let dstStyle := json% {"color": "#9cdcfe"}
         let reqStyle := json% {"color": "#c586c0", "fontStyle": "italic"}
-        let ctorStyle := json% {"color": "#4ec9b0"}
+        let _ctorStyle := json% {"color": "#4ec9b0"}
         let schedStyle := json% {"color": "#ce9178", "fontSize": "0.9em", "whiteSpace": "pre", "fontFamily": "var(--vscode-editor-font-family, monospace)"}
         let singletonStyle := json% {"color": "#b5cea8"}
         let mutualStyle := json% {"color": "#ce9178", "fontWeight": "bold"}
@@ -1742,7 +1742,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
             | some (.done indSched) =>
               let allScheds := indSched.baseSchedules ++ indSched.recSchedules
               let mut depCtors : Std.HashMap SpecKey (List Name) := {}
-              for (ctorName, schedule@(steps, _)) in allScheds do
+              for (ctorName, (steps, _)) in allScheds do
                 let deps := collectNonRecDeps steps
                 let relDeps := deps.filter (fun d => d.kind == .relation || d.kind == .checker)
                 for d in relDeps do


### PR DESCRIPTION
## What

Silence two `unused variable` linter warnings in `elabDeriveMutual` (`Specimen/DeriveConstrainedProducer.lean`):

- `ctorStyle` → `_ctorStyle` — the binding is dead (it's defined but never referenced).
- The `depCtors` loop's `schedule@(steps, _)` alias → `(steps, _)` — only `steps` is used; the `schedule` alias is unused.

## Why

Building `Specimen/DeriveConstrainedProducer.lean` on a clean recompile emits exactly these two warnings:

```
warning: Specimen/DeriveConstrainedProducer.lean:1562:12: unused variable `ctorStyle`
warning: Specimen/DeriveConstrainedProducer.lean:1745:29: unused variable `schedule`
```

After this change, the file rebuilds with zero unused-variable warnings.

## Notes

There's a third `schedule@(steps, _)` site (in `mkCtorItems`) that is intentionally **left untouched** — `schedule` is genuinely used there (`let (_, sort) := schedule`), so it does not warn. This PR only touches the two genuinely-unused bindings.

No behavioral change — purely lint cleanup.
