### PR TITLE
Fix negative polarity checking and extend enumerator base-case failsafe

### DIFF
--- a/Specimen/DecOpt.lean
+++ b/Specimen/DecOpt.lean
@@ -60,4 +60,10 @@ def andOpt (a : Except GenError Bool) (b : Except GenError Bool) : Except GenErr
 def andOptList (bs : List (Except GenError Bool)) : Except GenError Bool :=
   List.foldl andOpt (.ok true) bs
 
+/-- Negation lifted to `Except GenError Bool`: flips `ok true ↔ ok false`, propagates errors -/
+def negOpt (a : Except GenError Bool) : Except GenError Bool :=
+  match a with
+  | .ok b => .ok (!b)
+  | .error e => .error e
+
 end DecOpt

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -843,13 +843,19 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         | .Enumerator => pure subProducer
         | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
       recursiveProducers := recursiveProducers.push term
-    -- For checkers with recursive constructors, add a failsafe to the base case:
+    -- For checkers/enumerators with recursive constructors, add a failsafe to the base case:
     -- if no base constructor matches, return "unknown" (error) rather than "false",
     -- since a recursive constructor might succeed at a larger size.
     let baseProducersWithFailsafe ← do
-      if (key.deriveSort == .Checker || key.deriveSort == .Theorem) && !recursiveProducers.isEmpty then
-        let failsafe ← `((fun (_ : Unit) => $failFn $genericFailure))
-        pure (nonRecursiveProducers.push failsafe)
+      if !recursiveProducers.isEmpty then
+        match key.deriveSort with
+        | .Checker | .Theorem =>
+          let failsafe ← `((fun (_ : Unit) => $failFn $genericFailure))
+          pure (nonRecursiveProducers.push failsafe)
+        | .Enumerator =>
+          let failsafe ← `($failFn $genericFailure)
+          pure (nonRecursiveProducers.push failsafe)
+        | .Generator => pure nonRecursiveProducers
       else
         pure nonRecursiveProducers
     let baseProducers ← `([$baseProducersWithFailsafe,*])

--- a/Specimen/EnumeratorCombinators.lean
+++ b/Specimen/EnumeratorCombinators.lean
@@ -35,11 +35,9 @@ def enumerateFuel (fuel : Nat) (total : Nat) (es : List (ExceptT GenError Enumer
     -- and pick one out of the `total - k` remaining enumerators
     tryCatch e (fun _ => enumerateFuel fuel' (total - 1) es')
 
-/-- Combines all enumerators, filtering out failed ones -/
+/-- Combines all enumerators into a single lazy list. -/
 def enumerateAll (es : List (ExceptT GenError Enumerator α)) (fuel : Nat) : LazyList (Except GenError α) :=
-  es.foldl (fun acc e =>
-    LazyList.append (LazyList.filter (fun | .ok _ => true | _ => false) (e fuel)) acc
-  ) .lnil
+  es.foldl (fun acc e => LazyList.append (e fuel) acc) .lnil
 
 /-- Tries all enumerators from a list until one returns a `pure` value or all the enumerators have
     failed once. -/

--- a/Specimen/Enumerators.lean
+++ b/Specimen/Enumerators.lean
@@ -216,3 +216,17 @@ def runEnum [Enum α] (size : Nat) (limit : Nat := 10) : IO (List α) :=
     returning the enumerated list of `Except GenError α` values (containing up to `limit` elements) in the `IO` monad -/
 def runSizedEnum (sizedEnum : Nat → ExceptT GenError Enumerator α) (size : Nat) (limit : Nat := 10) : IO (List (Except GenError α)) :=
   return (LazyList.take limit $ (sizedEnum size) size)
+
+/-- Like `runSizedEnum`, but filters out errors and pairs each successful value with the
+    accumulated error count seen so far. A nonzero error count means the enumeration was
+    incomplete at this size — try a larger size for more results. -/
+def runSizedEnumOk (sizedEnum : Nat → ExceptT GenError Enumerator α) (size : Nat) : LazyList (α × Nat) :=
+  let raw := (sizedEnum size) size
+  let rec go (l : LazyList (Except GenError α)) (errCount : Nat) : LazyList (α × Nat) :=
+    match l with
+    | .lnil => .lnil
+    | .lcons x xs =>
+      match x with
+      | .ok v => .lcons (v, errCount) (Thunk.mk fun _ => go xs.get errCount)
+      | .error _ => go xs.get (errCount + 1)
+  go raw 0

--- a/Specimen/Idents.lean
+++ b/Specimen/Idents.lean
@@ -25,6 +25,9 @@ def auxDecFn : Ident := mkIdent $ Name.mkStr1 "aux_dec"
 /-- Ident for the `DecOpt.andOptList` checker combinator (see `DecOpt.lean`) -/
 def andOptListFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "andOptList"
 
+/-- Ident for the `DecOpt.negOpt` checker combinator (see `DecOpt.lean`) -/
+def negOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "negOpt"
+
 /-- Ident for `GeneratorCombinators.backtrack`. -/
 def genBacktrackFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "backtrack"
 

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -436,9 +436,8 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
       pure $ .MBind monadSort producer typedVars k
     | Source.Rec f args | Source.MutRec f args =>
       pure $ .MBind monadSort (recCall f fuelPrimeName sizePrimeName args) typedVars k
-  | .Check src _ =>
+  | .Check src polarity =>
 
-    -- TODO: double check if we need to pattern-match on `scheduleSort` here
     let checker :=
       match src with
       | Source.NonRec hypExpr =>
@@ -446,9 +445,10 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
       | Source.Rec f args | Source.MutRec f args =>
         recCall f fuelPrimeName sizePrimeName args
 
-    -- TODO: handle checking hypotheses w/ negative polarity (currently not handled)
+    let checker :=
+      if polarity then checker
+      else .MApp .allowImplicit (.MConst ``DecOpt.negOpt) [checker]
 
-    -- TODO: double check if this is right
     pure $ .MBind .Checker checker [] k
   | .Match explicit scrutinee pattern =>
     pure $ .MMatch explicit (.MId scrutinee) [(pattern, k), (wildCardPattern, .MFail)]

--- a/SpecimenTest/Enum/EnumeratorSizeTest.lean
+++ b/SpecimenTest/Enum/EnumeratorSizeTest.lean
@@ -31,12 +31,10 @@ derive_enumerator ∃ (n : _), onetrue' n
 info: 1
 -/
 #guard_msgs(info) in
-#eval (List.length) <$>
-  (runSizedEnum (limit := 10) (EnumSizedSuchThat.enumSizedST (fun t => onetrue t)) 5)
+#eval (LazyList.toList (runSizedEnumOk (EnumSizedSuchThat.enumSizedST (fun t => onetrue t)) 5)).length
 
 /--
 info: 1
 -/
 #guard_msgs(all) in
-#eval ((List.length) <$>
-  (runSizedEnum (limit := 10) (EnumSizedSuchThat.enumSizedST (fun t => onetrue' t)) 5))
+#eval (LazyList.toList (runSizedEnumOk (EnumSizedSuchThat.enumSizedST (fun t => onetrue' t)) 5)).length


### PR DESCRIPTION
## Summary
- Checkers now correctly handle negated hypotheses (`¬P`) by wrapping the checker with `DecOpt.negOpt` — previously the polarity `Bool` was silently ignored, treating `¬P` as `P`
- Extends the base-case failsafe (#18) to enumerators so they also return "unknown" rather than incorrectly terminating when recursive constructors exist
- Simplifies `enumerateAll` by removing redundant error filtering (errors now propagate in the lazy list)
- Adds `runSizedEnumOk` helper that filters errors and tracks accumulated error count

## Test plan
- [x] `lake build SpecimenTest` passes all 129 jobs
- [x] `EnumeratorSizeTest` updated to use `runSizedEnumOk`