### PR TITLE
Add monadic step scorer, ctorWeight emission, and new scoring strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,6 @@ def myCtorWeight (ctorName : Name) (outputIndices : List Nat) (deriveSort : Deri
     else max 1 (size / (max 1 numRec * 4))
   else 10
 
--- Register it (this runs at initialization time)
-initialize Scoring.registerWeightFn `myCtorWeight myCtorWeight ``myCtorWeight
-
 -- Use it for a specific derivation
 set_option specimen.weightFn "myCtorWeight" in
 derive_mutual
@@ -245,8 +242,6 @@ def myModifier (baseWeight : Nat) (ctorName : Name) (_outputIndices : List Nat)
   if ctorName == ``MyType.PreferredCtor then baseWeight * 3
   else if ctorName == ``MyType.ExpensiveCtor then baseWeight / 2
   else baseWeight
-
-initialize Scoring.registerWeightModifier `myModifier myModifier ``myModifier
 
 set_option specimen.weightModifier "myModifier" in
 derive_mutual

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ derive_checker (fun n t => balanced n t)
 | `specimen.autoDeriveDeps` | `false` | Automatically derive dependency instances for sub-relations in `derive_mutual` |
 | `specimen.multiOutput` | `false` | Allow multi-output production steps (multiple `∃` vars generated per hypothesis) |
 | `specimen.scoreType` | `"Scoring.DefaultScore"` | Scoring strategy for schedule quality evaluation (see below) |
+| `specimen.weightFn` | `"Scoring.balancedCtorWeight"` | Weight function for constructor frequency in derived generators (see below) |
+| `specimen.weightModifier` | `""` | Optional modifier layered on top of the weight function (see below) |
 | `specimen.fuel` | `10000` | Fuel (termination budget) for derived generators/enumerators/checkers |
 | `specimen.richOutput` | `true` | Emit rich HTML widget output in the Lean infoview |
 | `specimen.textOutput` | `0` | Plain-text output verbosity (0=off, 1=summary, 2=problems, 3=full) |
@@ -153,6 +155,105 @@ derive_mutual
 ```
 
 See [`ScheduleQualityRegressionTest.lean`](./SpecimenTest/ScheduleQualityRegressionTest.lean) for a comparison of all three strategies on the same relation.
+
+**Weight functions** control how often each constructor is chosen at runtime by the backtracking combinator. The `specimen.weightFn` option selects the active weight function. A weight function has the signature:
+
+```
+CtorWeightFn := Name → List Nat → DeriveSort → Float → Bool → Nat → Nat → Nat → Nat
+```
+
+Arguments: `(ctorName, outputIndices, deriveSort, scoreBadness, isRec, size, numBase, numRec) → weight`
+- `ctorName`: the fully qualified name of the constructor (e.g. `` `List.cons ``).
+- `outputIndices`: the output position indices for this derivation.
+- `deriveSort`: whether we are deriving a `Generator`, `Enumerator`, `Checker`, or `Theorem`.
+- `scoreBadness`: a [0,1] float from the scorer indicating schedule quality for this constructor (0 = best, 1 = worst). Computed at elaboration time and baked in as a literal.
+- `isRec`: whether this constructor is recursive.
+- `size`: the current generation size parameter (decreases as the generator recurses deeper).
+- `numBase` / `numRec`: counts of base vs recursive constructors for this inductive.
+
+The return value is a `Nat` weight — the backtracking combinator picks constructors proportionally to their weights. The `ctorName`, `outputIndices`, and `deriveSort` arguments enable per-constructor and per-mode weight overrides without needing to write a separate weight function for each type.
+
+| Weight function | Option value | Description |
+|----------------|-------------|-------------|
+| Balanced | `"Scoring.balancedCtorWeight"` | Controls aggregate P(recursive) with quality bias. Base ctors get a 4x boost. Good default for inductives with many recursive constructors. |
+| Size-proportional | `"Scoring.sizeProportionalCtorWeight"` | `base=1, rec=size+1`. The strategy used by QuickChick. |
+| Score-aware | `"Scoring.scoreAwareCtorWeight"` | Boosts good constructors (low badness 1–4) and applies size-based penalty to recursive ones. |
+| Quality-only | `"Scoring.qualityCtorWeight"` | No structural bias — maps badness to 1–4, ignores size/recursion. Use with budget splitting for termination. |
+| Flat | `"Scoring.flatCtorWeight"` | Every constructor gets weight 1. Ignores everything. |
+| Default | `"Scoring.defaultCtorWeight"` | `base=1, rec=numBase*size/numRec`. Ignores score. |
+
+For example, to use size-proportional weights (QuickChick-style):
+```lean
+set_option specimen.weightFn "Scoring.sizeProportionalCtorWeight"
+derive_mutual
+  (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
+```
+
+**Defining a custom weight function.** You can define and register your own weight function in your own file — no need to modify Specimen. This is useful when you've derived generators and found the distribution poorly tuned for your application:
+
+```lean
+import Specimen
+
+open Scoring Schedules in
+-- Custom weight function: heavily favor base cases
+def myCtorWeight (ctorName : Name) (outputIndices : List Nat) (deriveSort : DeriveSort)
+    (scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+  if isRec then
+    if size == 0 then 0
+    else max 1 (size / (max 1 numRec * 4))
+  else 10
+
+-- Register it (this runs at initialization time)
+initialize Scoring.registerWeightFn `myCtorWeight myCtorWeight ``myCtorWeight
+
+-- Use it for a specific derivation
+set_option specimen.weightFn "myCtorWeight" in
+derive_mutual
+  (fun n => ∃ (xs : List Nat), SortedList n xs)
+```
+
+**Targeting specific constructors.** The `ctorName`, `outputIndices`, and `deriveSort` arguments let you override weights for particular constructors or modes while falling back to a default for everything else:
+
+```lean
+open Scoring Schedules in
+def myTargetedWeight (ctorName : Name) (outputIndices : List Nat) (deriveSort : DeriveSort)
+    (scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+  -- Give a specific constructor a constant low weight
+  if ctorName == ``MyType.ExpensiveCtor then 1
+  -- Boost another constructor
+  else if ctorName == ``MyType.PreferredCtor then 8
+  -- Fall back to the default balanced strategy for everything else
+  else balancedCtorWeight ctorName outputIndices deriveSort scoreBadness isRec size numBase numRec
+```
+
+The `set_option ... in` scoping means different derivations in the same file can use different weight functions. After changing the weight function, rederive and recompile your file to produce a generator reflecting the new weights.
+
+**Weight modifiers.** Instead of replacing the entire weight function, you can layer a modifier on top. A `CtorWeightModifier` receives the base weight (already computed by the active weight function) as its first argument and can transform it — multiply, cap, override, or pass through:
+
+```
+CtorWeightModifier := Nat → Name → List Nat → DeriveSort → Float → Bool → Nat → Nat → Nat → Nat
+                      (baseWeight, ctorName, outputIndices, deriveSort, scoreBadness, isRec, size, numBase, numRec) → finalWeight
+```
+
+Example — triple the weight for a preferred constructor, halve an expensive one, leave everything else alone:
+
+```lean
+open Scoring Schedules in
+def myModifier (baseWeight : Nat) (ctorName : Name) (_outputIndices : List Nat)
+    (_deriveSort : DeriveSort) (_scoreBadness : Float) (_isRec : Bool)
+    (_size : Nat) (_numBase _numRec : Nat) : Nat :=
+  if ctorName == ``MyType.PreferredCtor then baseWeight * 3
+  else if ctorName == ``MyType.ExpensiveCtor then baseWeight / 2
+  else baseWeight
+
+initialize Scoring.registerWeightModifier `myModifier myModifier ``myModifier
+
+set_option specimen.weightModifier "myModifier" in
+derive_mutual
+  (fun n => ∃ (xs : List Nat), SortedList n xs)
+```
+
+The modifier composes with whatever `specimen.weightFn` is active — you don't need to know or reimplement the base weight logic. This is the lightest-weight way to nudge the distribution for specific constructors.
 
 ## Repo overview
 

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -171,7 +171,7 @@ def deriveScheduledChecker' (_args : Array Expr)
           -- (where each term represents a typeclass instance)
           let (subChecker, instances) ← StateT.run (s := #[]) (do
             let recType := unifyState.outputTypes.headD (mkConst ``Bool)
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) recType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) recType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := inductiveName)
             MExp.mexpToTSyntax mexp (deriveSort := .Checker))
 
           requiredInstances := requiredInstances ++ instances

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -797,6 +797,21 @@ def deriveConstrainedProducer
         | .Enumerator => `aux_enum
         | _ => `aux_dec)
 
+      -- Resolve the active weight function for constructor frequency
+      let weightEntry ← Scoring.getActiveWeightFn
+      let weightFnIdent := mkIdent weightEntry.leanName
+
+      -- Pre-count base vs recursive constructors for the weight function
+      let mut numBaseCtors := 0
+      let mut numRecCtors := 0
+      for ctorName in inductiveVal.ctors do
+        if ← isConstructorRecursive inductiveName ctorName then
+          numRecCtors := numRecCtors + 1
+        else
+          numBaseCtors := numBaseCtors + 1
+      let numBaseLit := Syntax.mkNumLit (toString numBaseCtors)
+      let numRecLit := Syntax.mkNumLit (toString numRecCtors)
+
       let mut requiredInstances := #[]
       for ctorName in inductiveVal.ctors do
         let resultOption ← (UnifyM.runInMetaM
@@ -811,7 +826,7 @@ def deriveConstrainedProducer
           -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
           -- (where each term represents a typeclass instance)
           let (subProducer, instances) ← StateT.run (s := #[]) (do
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := inductiveName)
             MExp.mexpToTSyntax mexp deriveSort)
 
           requiredInstances := requiredInstances ++ instances
@@ -821,21 +836,21 @@ def deriveConstrainedProducer
           let isRecursive ← isConstructorRecursive inductiveName ctorName
 
           if isRecursive then
-            -- Following the QuickChick convention,
-            -- recursive sub-generators have a weight of `.succ size'`
-            -- and sub-enumerators don't have any weight associated with them
+            -- recursive sub-generators use the active weight function with size'
+            -- sub-enumerators don't have any weight associated with them
             let subProducerTerm ←
               match producerSort with
-              | .Generator => `( ($(mkIdent ``Nat.succ) $freshSize', $subProducer) )
+              | .Generator =>
+                `( ($weightFnIdent 0.0 true $freshSize' $numBaseLit $numRecLit, $subProducer) )
               | .Enumerator => pure subProducer
             recursiveProducers := recursiveProducers.push subProducerTerm
           else
-            -- Following the QuickChick convention,
-            -- non-recursive sub-generators have a weight of 1
+            -- non-recursive sub-generators use the active weight function with size=0
             -- (sub-enumerators don't have any weight associated with them)
             let subGeneratorTerm ←
               match producerSort with
-              | .Generator => `( (1, $subProducer) )
+              | .Generator =>
+                `( ($weightFnIdent 0.0 false 0 $numBaseLit $numRecLit, $subProducer) )
               | .Enumerator => pure subProducer
             nonRecursiveProducers := nonRecursiveProducers.push subGeneratorTerm
 
@@ -912,12 +927,13 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         | .SuchThat vs (.Rec _ args) ps => .SuchThat vs (.Rec globalName args) ps
         | .Check (.Rec _ args) pol => .Check (.Rec globalName args) pol
         | other => other
+    let weightEntry ← Scoring.getActiveWeightFn
+    let weightFnIdent := mkIdent weightEntry.leanName
     let bundle ← Scoring.getActiveScorerBundle
-    let lookupCtorScore (ctorName : Name) : Array Nat :=
+    let lookupCtorBadness (ctorName : Name) : Float :=
       match indSched.ctorStats.find? (fun (n, _, _, _) => n == ctorName) with
-      | some (_, _, _, s) => bundle.ctorWeightArgs s
-      | none => #[1, 0, 0, 0]
-    -- Pre-compute numBase/numRec for ctorWeight (need to know which base schedules use mutual calls)
+      | some (_, _, _, s) => bundle.scoreBadness s
+      | none => 0.0
     let numBaseMutual := indSched.baseSchedules.filter (fun (_, (steps, _)) =>
       scheduleUsesMutualCall (rewriteSchedule steps))
     let numBase := indSched.baseSchedules.length - numBaseMutual.length
@@ -930,29 +946,20 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
       let rewrittenSchedule := (rewrittenSteps, sort)
       let (subProducer, _) ← StateT.run (s := #[]) (do
         let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
-          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := key.inductiveName)
         MExp.mexpToTSyntax mexp key.deriveSort)
+      let badnessLit := Syntax.mkScientificLit (toString (lookupCtorBadness ctorName))
       if scheduleUsesMutualCall rewrittenSteps then
         let term ← match key.deriveSort with
           | .Generator =>
-            let ws := lookupCtorScore ctorName
-            let dLit := Syntax.mkNumLit (toString ws[0]!)
-            let sLit := Syntax.mkNumLit (toString ws[1]!)
-            let lLit := Syntax.mkNumLit (toString ws[2]!)
-            let vLit := Syntax.mkNumLit (toString ws[3]!)
-            `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
+            `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
           | .Enumerator => pure subProducer
           | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
         recursiveProducers := recursiveProducers.push term
       else
         let term ← match key.deriveSort with
           | .Generator =>
-            let ws := lookupCtorScore ctorName
-            let dLit := Syntax.mkNumLit (toString ws[0]!)
-            let sLit := Syntax.mkNumLit (toString ws[1]!)
-            let lLit := Syntax.mkNumLit (toString ws[2]!)
-            let vLit := Syntax.mkNumLit (toString ws[3]!)
-            `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit false 0 $numBaseLit $numRecLit, $subProducer) )
+            `( ($weightFnIdent $badnessLit false 0 $numBaseLit $numRecLit, $subProducer) )
           | .Enumerator => pure subProducer
           | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
         nonRecursiveProducers := nonRecursiveProducers.push term
@@ -961,16 +968,12 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
       let rewrittenSchedule := (rewriteSchedule steps, sort)
       let (subProducer, _) ← StateT.run (s := #[]) (do
         let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
-          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := key.inductiveName)
         MExp.mexpToTSyntax mexp key.deriveSort)
+      let badnessLit := Syntax.mkScientificLit (toString (lookupCtorBadness ctorName))
       let term ← match key.deriveSort with
         | .Generator =>
-          let ws := lookupCtorScore ctorName
-          let dLit := Syntax.mkNumLit (toString ws[0]!)
-          let sLit := Syntax.mkNumLit (toString ws[1]!)
-          let lLit := Syntax.mkNumLit (toString ws[2]!)
-          let vLit := Syntax.mkNumLit (toString ws[3]!)
-          `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
+          `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
         | .Enumerator => pure subProducer
         | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
       recursiveProducers := recursiveProducers.push term
@@ -1379,6 +1382,18 @@ def deriveConstrainedProducerParts
       let freshSize' := mkIdent freshSizePrimeName
       let freshRecFnName := recFnNameOverride.getD (localCtx.getUnusedName (match deriveSort with
         | .Generator => `aux_arb | .Enumerator => `aux_enum | _ => `aux_dec))
+      -- Resolve the active weight function for constructor frequency
+      let weightEntry ← Scoring.getActiveWeightFn
+      let weightFnIdent := mkIdent weightEntry.leanName
+      -- Pre-count base vs recursive constructors for the weight function
+      let mut numBaseCtors := 0
+      let mut numRecCtors := 0
+      for ctorName in inductiveVal.ctors do
+        let isRec ← (isConstructorRecursive inductiveName ctorName)
+        if isRec then numRecCtors := numRecCtors + 1
+        else numBaseCtors := numBaseCtors + 1
+      let numBaseLit := Syntax.mkNumLit (toString numBaseCtors)
+      let numRecLit := Syntax.mkNumLit (toString numRecCtors)
       -- For each constructor: derive a schedule, compile to syntax
       for ctorName in inductiveVal.ctors do
         let resultOption ← (UnifyM.runInMetaM
@@ -1391,7 +1406,7 @@ def deriveConstrainedProducerParts
           let rewrittenSteps := scheduleRewriter scheduleSteps
           let schedule := (rewrittenSteps, scheduleSort)
           let (subProducer, requiredInsts) ← StateT.run (s := #[]) (do
-            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) _outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
+            let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) _outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := inductiveName)
             MExp.mexpToTSyntax mexp deriveSort)
           if !requiredInsts.isEmpty then
             let outputIdxsStr := outputNamesTypesIndices.map (fun (n, _, i) => s!"{n}@{i}")
@@ -1399,12 +1414,14 @@ def deriveConstrainedProducerParts
           let isRecursive ← (isConstructorRecursive inductiveName ctorName) <||> pure (scheduleUsesMutualCall rewrittenSteps)
           if isRecursive then
             let subProducerTerm ← match producerSort with
-              | .Generator => `( ($(mkIdent ``Nat.succ) $freshSize', $subProducer) )
+              | .Generator =>
+                `( ($weightFnIdent 0.0 true $freshSize' $numBaseLit $numRecLit, $subProducer) )
               | .Enumerator => pure subProducer
             recursiveProducers := recursiveProducers.push subProducerTerm
           else
             let subGeneratorTerm ← match producerSort with
-              | .Generator => `( (1, $subProducer) )
+              | .Generator =>
+                `( ($weightFnIdent 0.0 false 0 $numBaseLit $numRecLit, $subProducer) )
               | .Enumerator => pure subProducer
             nonRecursiveProducers := nonRecursiveProducers.push subGeneratorTerm
         | none => throwError m!"Unable to derive producer schedule for constructor {ctorName}"

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -797,7 +797,17 @@ def deriveConstrainedProducer
         | .Enumerator => `aux_enum
         | _ => `aux_dec)
 
-      -- Resolve the active weight function for constructor frequency
+      -- === Scoring integration ===
+      -- Each constructor gets a runtime weight that controls how often it's chosen by
+      -- the backtracking combinator for this derive sort. The weight depends on:
+      --   1. The constructor's "badness" (a [0,1] float from the active ScorerBundle's
+      --      `scoreBadness` — its meaning depends on the scoring strategy, e.g. check
+      --      count, density category, or worst-leaf penalty).
+      --   2. Whether it's recursive (rec ctors need size-dependent weighting to control
+      --      termination probability).
+      --   3. The current size parameter and the base/rec constructor counts.
+      -- The active weight function (e.g. defaultCtorWeight, scoreAwareCtorWeight) maps
+      -- these inputs to a Nat weight used by the backtracking combinator at runtime.
       let weightEntry ← Scoring.getActiveWeightFn
       let weightFnIdent := mkIdent weightEntry.leanName
 
@@ -877,6 +887,29 @@ def deriveConstrainedProducer
     constrainingInductive inductiveLevels freshArgIdents freshenedOutputNames.toList
     outputTypes.toList producerSort localCtx
 
+/-- Compile a schedule to a weighted sub-producer term. Handles the common pattern of:
+    schedule → MExp → TSyntax, then wrapping with the weight function for the backtracking
+    combinator. Returns the compiled term and whether it should go in the recursive bucket. -/
+private def compileWeightedProducer
+    (schedule : List ScheduleStep × ScheduleSort)
+    (outputType : Expr) (deriveSort : DeriveSort)
+    (fuelPrimeName sizePrimeName targetInductive : Name)
+    (weightFnIdent : Ident) (badness : Float) (isRecursive : Bool)
+    (freshSize' numBaseLit numRecLit : TSyntax `term) : TermElabM (TSyntax `term) := do
+  let (subProducer, _) ← StateT.run (s := #[]) (do
+    let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType
+      (fuelPrimeName := fuelPrimeName) (sizePrimeName := sizePrimeName) (targetInductive := targetInductive)
+    MExp.mexpToTSyntax mexp deriveSort)
+  let badnessLit := Syntax.mkScientificLit (toString badness)
+  match deriveSort with
+  | .Generator =>
+    if isRecursive then
+      `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
+    else
+      `( ($weightFnIdent $badnessLit false 0 $numBaseLit $numRecLit, $subProducer) )
+  | .Enumerator => pure subProducer
+  | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
+
 /-- Compiles an InductiveSchedule from the memo into (def, instance) commands.
     Uses the pre-derived schedules directly (no re-derivation).
     `siblings` is the list of specs in the same mutual block (for rewriting to Source.MutRec). -/
@@ -927,6 +960,11 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         | .SuchThat vs (.Rec _ args) ps => .SuchThat vs (.Rec globalName args) ps
         | .Check (.Rec _ args) pol => .Check (.Rec globalName args) pol
         | other => other
+    -- Constructors with expensive schedules (many checks, low density) should be
+    -- attempted less often at runtime to avoid wasted backtracking. We use the
+    -- per-constructor score from schedule search to bias the backtracking combinator's
+    -- weights accordingly. Base constructors with mutual calls are treated as recursive
+    -- because they still consume fuel.
     let weightEntry ← Scoring.getActiveWeightFn
     let weightFnIdent := mkIdent weightEntry.leanName
     let bundle ← Scoring.getActiveScorerBundle
@@ -943,39 +981,17 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
     for (ctorName, schedule) in indSched.baseSchedules do
       let (steps, sort) := schedule
       let rewrittenSteps := rewriteSchedule steps
-      let rewrittenSchedule := (rewrittenSteps, sort)
-      let (subProducer, _) ← StateT.run (s := #[]) (do
-        let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
-          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := key.inductiveName)
-        MExp.mexpToTSyntax mexp key.deriveSort)
-      let badnessLit := Syntax.mkScientificLit (toString (lookupCtorBadness ctorName))
-      if scheduleUsesMutualCall rewrittenSteps then
-        let term ← match key.deriveSort with
-          | .Generator =>
-            `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
-          | .Enumerator => pure subProducer
-          | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
-        recursiveProducers := recursiveProducers.push term
-      else
-        let term ← match key.deriveSort with
-          | .Generator =>
-            `( ($weightFnIdent $badnessLit false 0 $numBaseLit $numRecLit, $subProducer) )
-          | .Enumerator => pure subProducer
-          | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
-        nonRecursiveProducers := nonRecursiveProducers.push term
+      let isRec := scheduleUsesMutualCall rewrittenSteps
+      let term ← compileWeightedProducer (rewrittenSteps, sort) outputType key.deriveSort
+        freshFuelPrimeName freshSizePrimeName key.inductiveName
+        weightFnIdent (lookupCtorBadness ctorName) isRec freshSize' numBaseLit numRecLit
+      if isRec then recursiveProducers := recursiveProducers.push term
+      else nonRecursiveProducers := nonRecursiveProducers.push term
     for (ctorName, schedule) in indSched.recSchedules do
       let (steps, sort) := schedule
-      let rewrittenSchedule := (rewriteSchedule steps, sort)
-      let (subProducer, _) ← StateT.run (s := #[]) (do
-        let mexp ← MExp.scheduleToMExp rewrittenSchedule (.MId `size) (.MId `initSize) outputType
-          (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := key.inductiveName)
-        MExp.mexpToTSyntax mexp key.deriveSort)
-      let badnessLit := Syntax.mkScientificLit (toString (lookupCtorBadness ctorName))
-      let term ← match key.deriveSort with
-        | .Generator =>
-          `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
-        | .Enumerator => pure subProducer
-        | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
+      let term ← compileWeightedProducer (rewriteSchedule steps, sort) outputType key.deriveSort
+        freshFuelPrimeName freshSizePrimeName key.inductiveName
+        weightFnIdent (lookupCtorBadness ctorName) true freshSize' numBaseLit numRecLit
       recursiveProducers := recursiveProducers.push term
     -- For checkers/enumerators with recursive constructors, add a failsafe to the base case:
     -- if no base constructor matches, return "unknown" (error) rather than "false",

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -628,16 +628,16 @@ def getScheduleForInductiveRelationConstructor
           | .lcons fstSchdM rest =>
           let (fstSchd, countSeen) ← fstSchdM
           let inputVarSet := Std.HashSet.ofList fixedVars
-          let scoreSchedule := fun (steps : List ScheduleStep) =>
-            let stepScores := steps.map fun step => bundle.stepScorer key depMemo inputVarSet step
-            bundle.scheduleScorer stepScores
+          let scoreSchedule := fun (steps : List ScheduleStep) => do
+            let stepScores ← steps.mapM fun step => bundle.stepScorer key depMemo inputVarSet step
+            return bundle.scheduleScorer stepScores
           let mut countProcessed := 1
-          let mut bestScore := scoreSchedule fstSchd
+          let mut bestScore ← scoreSchedule fstSchd
           let mut bestSchedule := fstSchd
           trace[plausible.deriving.results] m!"First Schedule: {ppScheduleSteps bestSchedule} \nScore: {bundle.reprScore bestScore}\nSchedules Considered: {repr countSeen}\nSchedules Processed: {repr countProcessed}"
           for schdM in rest.get do
             let (schd, countSeen) ← schdM
-            let score := scoreSchedule schd
+            let score ← scoreSchedule schd
             countProcessed := countProcessed + 1
             if bundle.isBetter score bestScore then
               bestSchedule := schd
@@ -912,7 +912,19 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         | .SuchThat vs (.Rec _ args) ps => .SuchThat vs (.Rec globalName args) ps
         | .Check (.Rec _ args) pol => .Check (.Rec globalName args) pol
         | other => other
-    for (_, schedule) in indSched.baseSchedules do
+    let bundle ← Scoring.getActiveScorerBundle
+    let lookupCtorScore (ctorName : Name) : Array Nat :=
+      match indSched.ctorStats.find? (fun (n, _, _, _) => n == ctorName) with
+      | some (_, _, _, s) => bundle.ctorWeightArgs s
+      | none => #[1, 0, 0, 0]
+    -- Pre-compute numBase/numRec for ctorWeight (need to know which base schedules use mutual calls)
+    let numBaseMutual := indSched.baseSchedules.filter (fun (_, (steps, _)) =>
+      scheduleUsesMutualCall (rewriteSchedule steps))
+    let numBase := indSched.baseSchedules.length - numBaseMutual.length
+    let numRec := indSched.recSchedules.length + numBaseMutual.length
+    let numBaseLit := Syntax.mkNumLit (toString numBase)
+    let numRecLit := Syntax.mkNumLit (toString numRec)
+    for (ctorName, schedule) in indSched.baseSchedules do
       let (steps, sort) := schedule
       let rewrittenSteps := rewriteSchedule steps
       let rewrittenSchedule := (rewrittenSteps, sort)
@@ -922,17 +934,29 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
         MExp.mexpToTSyntax mexp key.deriveSort)
       if scheduleUsesMutualCall rewrittenSteps then
         let term ← match key.deriveSort with
-          | .Generator => `( ($(Lean.mkIdent ``Nat.succ) $freshSize', $subProducer) )
+          | .Generator =>
+            let ws := lookupCtorScore ctorName
+            let dLit := Syntax.mkNumLit (toString ws[0]!)
+            let sLit := Syntax.mkNumLit (toString ws[1]!)
+            let lLit := Syntax.mkNumLit (toString ws[2]!)
+            let vLit := Syntax.mkNumLit (toString ws[3]!)
+            `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
           | .Enumerator => pure subProducer
           | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
         recursiveProducers := recursiveProducers.push term
       else
         let term ← match key.deriveSort with
-          | .Generator => `( (1, $subProducer) )
+          | .Generator =>
+            let ws := lookupCtorScore ctorName
+            let dLit := Syntax.mkNumLit (toString ws[0]!)
+            let sLit := Syntax.mkNumLit (toString ws[1]!)
+            let lLit := Syntax.mkNumLit (toString ws[2]!)
+            let vLit := Syntax.mkNumLit (toString ws[3]!)
+            `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit false 0 $numBaseLit $numRecLit, $subProducer) )
           | .Enumerator => pure subProducer
           | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
         nonRecursiveProducers := nonRecursiveProducers.push term
-    for (_, schedule) in indSched.recSchedules do
+    for (ctorName, schedule) in indSched.recSchedules do
       let (steps, sort) := schedule
       let rewrittenSchedule := (rewriteSchedule steps, sort)
       let (subProducer, _) ← StateT.run (s := #[]) (do
@@ -940,7 +964,13 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
           (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName)
         MExp.mexpToTSyntax mexp key.deriveSort)
       let term ← match key.deriveSort with
-        | .Generator => `( ($(Lean.mkIdent ``Nat.succ) $freshSize', $subProducer) )
+        | .Generator =>
+          let ws := lookupCtorScore ctorName
+          let dLit := Syntax.mkNumLit (toString ws[0]!)
+          let sLit := Syntax.mkNumLit (toString ws[1]!)
+          let lLit := Syntax.mkNumLit (toString ws[2]!)
+          let vLit := Syntax.mkNumLit (toString ws[3]!)
+          `( (Scoring.ctorWeight $dLit $sLit $lLit $vLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
         | .Enumerator => pure subProducer
         | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
       recursiveProducers := recursiveProducers.push term
@@ -1670,6 +1700,41 @@ def elabDeriveMutual : CommandElab := fun stx => do
               |>.filter (usedKeys.contains ·) |>.eraseDups
             totalEdges := totalEdges + depKeys.length
           | _ => pure ()
+        -- Compile all components BEFORE building the widget so we can show generated code
+        let mut compiledComponents : Array (Array (SpecKey × Name) × Array (TSyntax `command) × Array (TSyntax `command)) := #[]
+        let mut compiledCodeMap : Std.HashMap SpecKey (String × String) := {}
+        for comp in components do
+          let mut compMeta : Array (SpecKey × Name) := #[]
+          for key in comp do
+            let uid ← liftTermElabM (Lean.Core.mkFreshUserName `specimen_mutual)
+            let globalName := Name.mkSimple s!"{uid}_{key.inductiveName.toString.replace "." "_"}"
+            compMeta := compMeta.push (key, globalName)
+          let compSiblings : List (Name × List Nat × Name × DeriveSort) :=
+            compMeta.toList.map (fun (k, gn) => (k.inductiveName, k.outputIndices, gn, k.deriveSort))
+          let mut defCmds : Array (TSyntax `command) := #[]
+          let mut instCmds : Array (TSyntax `command) := #[]
+          for (key, globalName) in compMeta do
+            match finalMemo[key]? with
+            | some (.done indSched) =>
+              if indSched.alreadyExists then continue
+              try
+                let (defCmd, instCmd) ← liftTermElabM <|
+                  compileInductiveSchedule indSched globalName compSiblings
+                defCmds := defCmds.push defCmd
+                instCmds := instCmds.push instCmd
+                let defStr ← liftTermElabM <| try
+                  let fmt ← Lean.PrettyPrinter.ppCommand defCmd
+                  pure fmt.pretty
+                catch _ => pure "(failed to pretty-print def)"
+                let instStr ← liftTermElabM <| try
+                  let fmt ← Lean.PrettyPrinter.ppCommand instCmd
+                  pure fmt.pretty
+                catch _ => pure "(failed to pretty-print instance)"
+                compiledCodeMap := compiledCodeMap.insert key (defStr, instStr)
+              catch e =>
+                logWarning m!"Failed to compile {key.inductiveName}{key.outputIndices}{repr key.deriveSort}: {e.toMessageData}"
+            | _ => logWarning m!"No schedule found for {key.inductiveName}{key.outputIndices}"
+          compiledComponents := compiledComponents.push (compMeta, defCmds, instCmds)
         -- Build HTML output using ProofWidgets (controlled by specimen.richOutput)
         let richOutput := Lean.Option.get (← getOptions) specimen.richOutput
         let mkSpan (style : Json) (text : String) : Html :=
@@ -1776,12 +1841,22 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 let ctorItems := mkCtorItems indSched
                 let specNameStyle := json% {"color": $(specColor indSched), "fontWeight": "bold"}
                 let indScoreStr := bundle.reprScore indSched.score
+                let codeDropdown : Array Html := match compiledCodeMap[k]? with
+                  | some (defStr, instStr) =>
+                    let codeStyle := json% {"whiteSpace": "pre-wrap", "fontFamily": "var(--vscode-editor-font-family, monospace)", "fontSize": "0.85em", "lineHeight": "1.4", "padding": "8px", "background": "#0d1117", "borderRadius": "4px", "border": "1px solid #30363d", "overflow": "auto", "maxHeight": "400px"}
+                    #[Html.element "details" #[] #[
+                      .element "summary" #[("style", json% {"cursor": "pointer", "marginTop": "4px", "marginBottom": "2px"})] #[
+                        mkSpan (json% {"color": "#79c0ff", "fontSize": "0.9em"}) "📝 generated code"
+                      ],
+                      .element "div" #[("style", codeStyle)] #[.text (defStr ++ "\n\n" ++ instStr)]
+                    ]]
+                  | none => #[]
                 mutualItems := mutualItems.push (Html.element "details" #[] #[
                   .element "summary" #[("style", json% {"cursor": "pointer", "marginBottom": "2px"})] #[
                     mkSpan specNameStyle (k.prettyPrint numArgs),
                     mkSpan scoreStyle s!" ({nCtors} ctors{timeStr}) score: {indScoreStr}"
                   ],
-                  .element "div" #[("style", json% {"marginLeft": "12px"})] ctorItems
+                  .element "div" #[("style", json% {"marginLeft": "12px"})] (ctorItems ++ codeDropdown)
                 ])
               | _ => pure ()
             orderItems := orderItems.push (.element "div" #[("style", json% {"marginBottom": "6px", "paddingLeft": "4px", "borderLeft": "3px solid #ce9178"})] (#[
@@ -1805,13 +1880,23 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 let ctorItems := mkCtorItems indSched
                 let specNameStyle := json% {"color": $(specColor indSched), "fontWeight": "bold"}
                 let indScoreStr := bundle.reprScore indSched.score
+                let codeDropdown : Array Html := match compiledCodeMap[k]? with
+                  | some (defStr, instStr) =>
+                    let codeStyle := json% {"whiteSpace": "pre-wrap", "fontFamily": "var(--vscode-editor-font-family, monospace)", "fontSize": "0.85em", "lineHeight": "1.4", "padding": "8px", "background": "#0d1117", "borderRadius": "4px", "border": "1px solid #30363d", "overflow": "auto", "maxHeight": "400px"}
+                    #[Html.element "details" #[] #[
+                      .element "summary" #[("style", json% {"cursor": "pointer", "marginTop": "4px", "marginBottom": "2px"})] #[
+                        mkSpan (json% {"color": "#79c0ff", "fontSize": "0.9em"}) "📝 generated code"
+                      ],
+                      .element "div" #[("style", codeStyle)] #[.text (defStr ++ "\n\n" ++ instStr)]
+                    ]]
+                  | none => #[]
                 orderItems := orderItems.push (Html.element "details" #[] #[
                   .element "summary" #[("style", json% {"cursor": "pointer", "marginBottom": "2px"})] #[
                     .text "● ",
                     mkSpan specNameStyle (k.prettyPrint numArgs),
                     mkSpan scoreStyle s!" ({nCtors} ctors{timeStr}) score: {indScoreStr}"
                   ],
-                  .element "div" #[("style", json% {"marginLeft": "12px"})] ctorItems
+                  .element "div" #[("style", json% {"marginLeft": "12px"})] (ctorItems ++ codeDropdown)
                 ])
             | _ => pure ()
         htmlChildren := htmlChildren.push (Html.element "details" #[("open", json% true)] #[
@@ -2045,37 +2130,30 @@ def elabDeriveMutual : CommandElab := fun stx => do
                     let ctorStrs := ctors.map (fun n => n.getString!)
                     lines := lines.push s!"    requires {dk.prettyPrint dkArgs}  via {String.intercalate ", " ctorStrs}"
               | _ => pure ()
+          if textLevel ≥ 3 then
+            lines := lines.push ""
+            lines := lines.push "── Generated Code ──"
+            for (_, defCmds, instCmds) in compiledComponents do
+              if defCmds.isEmpty then continue
+              let mutualCmd ← if defCmds.size > 1 then
+                `(command| mutual $defCmds* end)
+              else pure defCmds[0]!
+              let mutualStr ← liftTermElabM <| try
+                let fmt ← Lean.PrettyPrinter.ppCommand mutualCmd
+                pure fmt.pretty
+              catch _ => pure "(failed to pretty-print)"
+              lines := lines.push mutualStr
+              for instCmd in instCmds do
+                let instStr ← liftTermElabM <| try
+                  let fmt ← Lean.PrettyPrinter.ppCommand instCmd
+                  pure fmt.pretty
+                catch _ => pure "(failed to pretty-print)"
+                lines := lines.push instStr
+              lines := lines.push ""
           logInfo m!"{String.intercalate "\n" lines.toList}"
-        -- For each component: assign names, compile, emit
-        for comp in components do
-          -- Assign global names for this component
-          let mut compMeta : Array (SpecKey × Name) := #[]
-          for key in comp do
-            let uid ← liftTermElabM (Lean.Core.mkFreshUserName `specimen_mutual)
-            let globalName := Name.mkSimple s!"{uid}_{key.inductiveName.toString.replace "." "_"}"
-            compMeta := compMeta.push (key, globalName)
-          -- Build siblings list for this component (for MutRec rewriting)
-          let compSiblings : List (Name × List Nat × Name × DeriveSort) :=
-            compMeta.toList.map (fun (k, gn) => (k.inductiveName, k.outputIndices, gn, k.deriveSort))
-          -- Compile each spec in the component
-          let mut defCmds : Array (TSyntax `command) := #[]
-          let mut instCmds : Array (TSyntax `command) := #[]
-          for (key, globalName) in compMeta do
-            match finalMemo[key]? with
-            | some (.done indSched) =>
-              if indSched.alreadyExists then continue
-              try
-                let (defCmd, instCmd) ← liftTermElabM <|
-                  compileInductiveSchedule indSched globalName compSiblings
-                defCmds := defCmds.push defCmd
-                instCmds := instCmds.push instCmd
-              catch e =>
-                logWarning m!"Failed to compile {key.inductiveName}{key.outputIndices}{repr key.deriveSort}: {e.toMessageData}"
-            | _ => logWarning m!"No schedule found for {key.inductiveName}{key.outputIndices}"
-          let getNumArgs (k : SpecKey) : CommandElabM Nat := liftTermElabM do
-            try pure ((← getComponentsOfArrowType (← getConstInfoInduct k.inductiveName).type).size - 1)
-            catch _ => pure k.outputIndices.length
-          -- Emit: mutual block for multi-element, standalone for singletons
+        -- Emit compiled components (already compiled above for the widget)
+        for (compMeta, defCmds, instCmds) in compiledComponents do
+          if defCmds.isEmpty then continue
           let specDescs ← compMeta.toList.mapM fun (k, _) => do
             let numArgs ← getNumArgs k
             let scoreStr := match finalMemo[k]? with

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -808,8 +808,18 @@ def deriveConstrainedProducer
       --   3. The current size parameter and the base/rec constructor counts.
       -- The active weight function (e.g. defaultCtorWeight, scoreAwareCtorWeight) maps
       -- these inputs to a Nat weight used by the backtracking combinator at runtime.
+      -- Users can define and register custom weight functions in their own files — see
+      -- README.md and the docstring on `CtorWeightFn` in Scoring.lean.
       let weightEntry ← Scoring.getActiveWeightFn
       let weightFnIdent := mkIdent weightEntry.leanName
+      let modifierEntry ← Scoring.getActiveWeightModifier
+      let modifierIdent : Option Ident := modifierEntry.map (fun e => mkIdent e.leanName)
+      let outputIndicesLit := Lean.quote outputIdxs.toList
+      let deriveSortLit ← match deriveSort with
+        | .Generator => `(Schedules.DeriveSort.Generator)
+        | .Enumerator => `(Schedules.DeriveSort.Enumerator)
+        | .Checker => `(Schedules.DeriveSort.Checker)
+        | .Theorem => `(Schedules.DeriveSort.Theorem)
 
       -- Pre-count base vs recursive constructors for the weight function
       let mut numBaseCtors := 0
@@ -831,36 +841,35 @@ def deriveConstrainedProducer
         match resultOption with
         | some result =>
           let schedule := result.schedule
-          -- Obtain a sub-producer for this constructor, along with an array of all typeclass instances that need to be defined beforehand.
-          -- (Under the hood, we compile the schedule to an `MExp`, then compile the `MExp` to a Lean term containing the code for the sub-producer.
-          -- This is all done in a state monad: when we detect that a new instance is required, we append it to an array of `TSyntax term`s
-          -- (where each term represents a typeclass instance)
           let (subProducer, instances) ← StateT.run (s := #[]) (do
             let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType (fuelPrimeName := freshFuelPrimeName) (sizePrimeName := freshSizePrimeName) (targetInductive := inductiveName)
             MExp.mexpToTSyntax mexp deriveSort)
 
           requiredInstances := requiredInstances ++ instances
 
-          -- Determine whether the constructor is recursive
-          -- (i.e. if the constructor has a hypothesis that refers to the inductive relation we are targeting)
           let isRecursive ← isConstructorRecursive inductiveName ctorName
+          let ctorNameLit := Lean.quote ctorName
 
           if isRecursive then
-            -- recursive sub-generators use the active weight function with size'
-            -- sub-enumerators don't have any weight associated with them
             let subProducerTerm ←
               match producerSort with
               | .Generator =>
-                `( ($weightFnIdent 0.0 true $freshSize' $numBaseLit $numRecLit, $subProducer) )
+                let baseWeight ← `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 true $freshSize' $numBaseLit $numRecLit)
+                let finalWeight ← match modifierIdent with
+                  | none => pure baseWeight
+                  | some modIdent => `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 true $freshSize' $numBaseLit $numRecLit)
+                `( ($finalWeight, $subProducer) )
               | .Enumerator => pure subProducer
             recursiveProducers := recursiveProducers.push subProducerTerm
           else
-            -- non-recursive sub-generators use the active weight function with size=0
-            -- (sub-enumerators don't have any weight associated with them)
             let subGeneratorTerm ←
               match producerSort with
               | .Generator =>
-                `( ($weightFnIdent 0.0 false 0 $numBaseLit $numRecLit, $subProducer) )
+                let baseWeight ← `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 false 0 $numBaseLit $numRecLit)
+                let finalWeight ← match modifierIdent with
+                  | none => pure baseWeight
+                  | some modIdent => `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 false 0 $numBaseLit $numRecLit)
+                `( ($finalWeight, $subProducer) )
               | .Enumerator => pure subProducer
             nonRecursiveProducers := nonRecursiveProducers.push subGeneratorTerm
 
@@ -894,19 +903,37 @@ private def compileWeightedProducer
     (schedule : List ScheduleStep × ScheduleSort)
     (outputType : Expr) (deriveSort : DeriveSort)
     (fuelPrimeName sizePrimeName targetInductive : Name)
-    (weightFnIdent : Ident) (badness : Float) (isRecursive : Bool)
+    (weightFnIdent : Ident) (modifierIdent : Option Ident)
+    (ctorName : Name) (outputIndices : List Nat)
+    (badness : Float) (isRecursive : Bool)
     (freshSize' numBaseLit numRecLit : TSyntax `term) : TermElabM (TSyntax `term) := do
   let (subProducer, _) ← StateT.run (s := #[]) (do
     let mexp ← MExp.scheduleToMExp schedule (.MId `size) (.MId `initSize) outputType
       (fuelPrimeName := fuelPrimeName) (sizePrimeName := sizePrimeName) (targetInductive := targetInductive)
     MExp.mexpToTSyntax mexp deriveSort)
   let badnessLit := Syntax.mkScientificLit (toString badness)
+  let ctorNameLit := Lean.quote ctorName
+  let outputIndicesLit := Lean.quote outputIndices
+  let deriveSortLit ← match deriveSort with
+    | .Generator => `(Schedules.DeriveSort.Generator)
+    | .Enumerator => `(Schedules.DeriveSort.Enumerator)
+    | .Checker => `(Schedules.DeriveSort.Checker)
+    | .Theorem => `(Schedules.DeriveSort.Theorem)
   match deriveSort with
   | .Generator =>
-    if isRecursive then
-      `( ($weightFnIdent $badnessLit true $freshSize' $numBaseLit $numRecLit, $subProducer) )
-    else
-      `( ($weightFnIdent $badnessLit false 0 $numBaseLit $numRecLit, $subProducer) )
+    let baseWeight ←
+      if isRecursive then
+        `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit $badnessLit true $freshSize' $numBaseLit $numRecLit)
+      else
+        `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit $badnessLit false 0 $numBaseLit $numRecLit)
+    let finalWeight ← match modifierIdent with
+      | none => pure baseWeight
+      | some modIdent =>
+        if isRecursive then
+          `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit $badnessLit true $freshSize' $numBaseLit $numRecLit)
+        else
+          `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit $badnessLit false 0 $numBaseLit $numRecLit)
+    `( ($finalWeight, $subProducer) )
   | .Enumerator => pure subProducer
   | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
 
@@ -967,6 +994,8 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
     -- because they still consume fuel.
     let weightEntry ← Scoring.getActiveWeightFn
     let weightFnIdent := mkIdent weightEntry.leanName
+    let modifierEntry ← Scoring.getActiveWeightModifier
+    let modifierIdent : Option Ident := modifierEntry.map (fun e => mkIdent e.leanName)
     let bundle ← Scoring.getActiveScorerBundle
     let lookupCtorBadness (ctorName : Name) : Float :=
       match indSched.ctorStats.find? (fun (n, _, _, _) => n == ctorName) with
@@ -984,14 +1013,14 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
       let isRec := scheduleUsesMutualCall rewrittenSteps
       let term ← compileWeightedProducer (rewrittenSteps, sort) outputType key.deriveSort
         freshFuelPrimeName freshSizePrimeName key.inductiveName
-        weightFnIdent (lookupCtorBadness ctorName) isRec freshSize' numBaseLit numRecLit
+        weightFnIdent modifierIdent ctorName key.outputIndices (lookupCtorBadness ctorName) isRec freshSize' numBaseLit numRecLit
       if isRec then recursiveProducers := recursiveProducers.push term
       else nonRecursiveProducers := nonRecursiveProducers.push term
     for (ctorName, schedule) in indSched.recSchedules do
       let (steps, sort) := schedule
       let term ← compileWeightedProducer (rewriteSchedule steps, sort) outputType key.deriveSort
         freshFuelPrimeName freshSizePrimeName key.inductiveName
-        weightFnIdent (lookupCtorBadness ctorName) true freshSize' numBaseLit numRecLit
+        weightFnIdent modifierIdent ctorName key.outputIndices (lookupCtorBadness ctorName) true freshSize' numBaseLit numRecLit
       recursiveProducers := recursiveProducers.push term
     -- For checkers/enumerators with recursive constructors, add a failsafe to the base case:
     -- if no base constructor matches, return "unknown" (error) rather than "false",
@@ -1398,9 +1427,17 @@ def deriveConstrainedProducerParts
       let freshSize' := mkIdent freshSizePrimeName
       let freshRecFnName := recFnNameOverride.getD (localCtx.getUnusedName (match deriveSort with
         | .Generator => `aux_arb | .Enumerator => `aux_enum | _ => `aux_dec))
-      -- Resolve the active weight function for constructor frequency
+      -- Resolve the active weight function and optional modifier for constructor frequency
       let weightEntry ← Scoring.getActiveWeightFn
       let weightFnIdent := mkIdent weightEntry.leanName
+      let modifierEntry ← Scoring.getActiveWeightModifier
+      let modifierIdent : Option Ident := modifierEntry.map (fun e => mkIdent e.leanName)
+      let outputIndicesLit := Lean.quote outputIdxs.toList
+      let deriveSortLit ← match deriveSort with
+        | .Generator => `(Schedules.DeriveSort.Generator)
+        | .Enumerator => `(Schedules.DeriveSort.Enumerator)
+        | .Checker => `(Schedules.DeriveSort.Checker)
+        | .Theorem => `(Schedules.DeriveSort.Theorem)
       -- Pre-count base vs recursive constructors for the weight function
       let mut numBaseCtors := 0
       let mut numRecCtors := 0
@@ -1428,16 +1465,25 @@ def deriveConstrainedProducerParts
             let outputIdxsStr := outputNamesTypesIndices.map (fun (n, _, i) => s!"{n}@{i}")
             trace[plausible.deriving.arbitrary] m!"[{repr deriveSort}] {inductiveName} (outputs: {outputIdxsStr}) constructor {ctorName} requires: {requiredInsts}"
           let isRecursive ← (isConstructorRecursive inductiveName ctorName) <||> pure (scheduleUsesMutualCall rewrittenSteps)
+          let ctorNameLit := Lean.quote ctorName
           if isRecursive then
             let subProducerTerm ← match producerSort with
               | .Generator =>
-                `( ($weightFnIdent 0.0 true $freshSize' $numBaseLit $numRecLit, $subProducer) )
+                let baseWeight ← `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 true $freshSize' $numBaseLit $numRecLit)
+                let finalWeight ← match modifierIdent with
+                  | none => pure baseWeight
+                  | some modIdent => `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 true $freshSize' $numBaseLit $numRecLit)
+                `( ($finalWeight, $subProducer) )
               | .Enumerator => pure subProducer
             recursiveProducers := recursiveProducers.push subProducerTerm
           else
             let subGeneratorTerm ← match producerSort with
               | .Generator =>
-                `( ($weightFnIdent 0.0 false 0 $numBaseLit $numRecLit, $subProducer) )
+                let baseWeight ← `($weightFnIdent $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 false 0 $numBaseLit $numRecLit)
+                let finalWeight ← match modifierIdent with
+                  | none => pure baseWeight
+                  | some modIdent => `($modIdent $baseWeight $ctorNameLit $outputIndicesLit $deriveSortLit 0.0 false 0 $numBaseLit $numRecLit)
+                `( ($finalWeight, $subProducer) )
               | .Enumerator => pure subProducer
             nonRecursiveProducers := nonRecursiveProducers.push subGeneratorTerm
         | none => throwError m!"Unable to derive producer schedule for constructor {ctorName}"

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -1316,7 +1316,7 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
       (step : PreScheduleStep HypothesisExpr Name) (_env : Std.HashSet Name) => do
     let typedStep := typePreScheduleStep nameTypeMap step
     let schedSteps ← (preScheduleStepToScheduleStep ctorName typedStep).run scheduleEnv
-    let stepScores := schedSteps.map fun s => bundle.stepScorer key memoState inputVarSet s
+    let stepScores ← schedSteps.mapM fun s => bundle.stepScorer key memoState inputVarSet s
     return stepScores
 
   -- Helper: process mode choices for one hypothesis (replicates processChoice logic)
@@ -1360,7 +1360,7 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
       | some (choice, _) => pure choice
 
   -- Helper: given a hypothesis ordering for one component, process it through
-  -- mode choices and return the resulting pre-schedule steps + final env
+  -- mode choices and return the resulting pre-schedule steps + final env.
   let processOrdering := fun (ordering : List (HypothesisExpr × List (List Name)))
       (env : List Name) (envSet : Std.HashSet Name) => do
     let constructedHyps := ordering.map (constructHypothesis typeVars delegableMap)
@@ -1380,14 +1380,17 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
         remaining := to_be_satisfied'
     return (sched, currentEnv, currentEnvSet)
 
-  -- Dominance pruning: tracks best score for each env state (sorted bound var set)
+  -- Dominance pruning: only at leaves (complete orderings for this SCC component).
+  -- The tree calls score on intermediates too (for branch-and-bound), but dominance
+  -- only compares complete schedules — matching the legacy path's semantics where
+  -- dominance compared finished SCC permutations against each other.
   let envDominanceRef ← IO.mkRef ({} : Std.HashMap (List Name) Score)
 
   -- Helper: score an ordering via processChoice → ScheduleSteps → bundle.
-  -- Dominance: if this env state was reached before with a better score, return worstScore.
   -- On-demand: derives unknown deps before scoring.
   let scoreComponentOrdering := fun (env : List Name) (envSet : Std.HashSet Name)
-      (ordering : List (HypothesisExpr × List (List Name))) => do
+      (ordering : List (HypothesisExpr × List (List Name)))
+      (sccSize : Nat) => do
     let (compSched, compEnv, _) ← processOrdering ordering env envSet
     let typedSteps := compSched.map (typePreScheduleStep nameTypeMap)
     let schedSteps ← (typedSteps.flatMapM (preScheduleStepToScheduleStep ctorName)).run scheduleEnv
@@ -1403,18 +1406,20 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
           unless m.contains depKey do deriveDep depKey
     -- Score
     let memoState ← memo.get
-    let score := bundle.scheduleScorer (schedSteps.map fun step => bundle.stepScorer key memoState inputVarSet step)
-    -- Dominance check (same structure as original: if dominated, signal pruning)
-    let envKey := compEnv.eraseDups |>.mergeSort (fun a b => compare a b |>.isLE)
-    let envDom ← envDominanceRef.get
-    match envDom[envKey]? with
-    | some prevBest =>
-      if bundle.isBetter prevBest score then return bundle.worstScore
-    | none => pure ()
-    envDominanceRef.modify fun m =>
-      match m[envKey]? with
-      | some prev => if bundle.isBetter score prev then m.insert envKey score else m
-      | none => m.insert envKey score
+    let stepScores ← schedSteps.mapM fun step => bundle.stepScorer key memoState inputVarSet step
+    let score := bundle.scheduleScorer stepScores
+    -- Dominance check: only at leaves (complete component orderings)
+    if ordering.length == sccSize then
+      let envKey := compEnv.eraseDups |>.mergeSort (fun a b => compare a b |>.isLE)
+      let envDom ← envDominanceRef.get
+      match envDom[envKey]? with
+      | some prevBest =>
+        if bundle.isBetter prevBest score then return bundle.worstScore
+      | none => pure ()
+      envDominanceRef.modify fun m =>
+        match m[envKey]? with
+        | some prev => if bundle.isBetter score prev then m.insert envKey score else m
+        | none => m.insert envKey score
     return score
 
   -- 4. Process SCC components sequentially using minTreePruningM per component
@@ -1422,18 +1427,17 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
   let mut accEnv : List Name := fixedVars
   let mut accEnvSet : Std.HashSet Name := Std.HashSet.ofList fixedVars
 
-  for (_, tree) in componentTrees do
+  for (sccGroup, tree) in componentTrees do
     if ← done.get then break
+    let sccSize := sccGroup.length
     -- Use minTreePruningM to find the best ordering for this component
     let componentDone ← IO.mkRef false
-    -- Tree yields List α where α = HypothesisExpr × List (List Name)
-    -- (the List Name from rawHypotheses is consumed as v for SCC edges)
     let componentBestRef ← IO.mkRef (none : Option (List (PreScheduleStep HypothesisExpr Name) × List Name × Std.HashSet Name × Score))
     let componentWorst := bundle.worstScore
     let envSnapshot := accEnv
     let envSetSnapshot := accEnvSet
 
-    let _ ← SearchTree.minTreePruningM tree (scoreComponentOrdering envSnapshot envSetSnapshot)
+    let _ ← SearchTree.minTreePruningM tree (scoreComponentOrdering envSnapshot envSetSnapshot · sccSize)
       bundle.isBetter componentWorst componentDone
       fun (ordering, score) currentBest => do
         let c ← countRef.get
@@ -1485,7 +1489,7 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
   -- 7. Score using the bundle with up-to-date memo
   let memoState ← memo.get
   let fullScore := bundle.scheduleScorer
-    (scheduleSteps.map fun step => bundle.stepScorer key memoState inputVarSet step)
+    (← scheduleSteps.mapM fun step => bundle.stepScorer key memoState inputVarSet step)
   bestRef.set (some (scheduleSteps, fullScore))
 
   let count ← countRef.get

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -1259,8 +1259,6 @@ def possibleSchedules (ctorName : Name) (vars : List TypedVar) (hypotheses : Lis
        schedule found.
     4. When scoring encounters a sub-relation dependency not yet derived,
        invoke `deriveDep` to derive it on demand (populates the memo).
-    5. Apply dominance pruning: if the same set of bound variables was reached
-       before with a better score, skip.
 
     **Legacy path**: when `memoRef` is unavailable (e.g. standalone
     `derive_checker`), the caller falls back to `possibleSchedules` which uses
@@ -1381,18 +1379,11 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
         remaining := to_be_satisfied'
     return (sched, currentEnv, currentEnvSet)
 
-  -- Dominance pruning: only at leaves (complete orderings for this SCC component).
-  -- The tree calls score on intermediates too (for branch-and-bound), but dominance
-  -- only compares complete schedules — matching the legacy path's semantics where
-  -- dominance compared finished SCC permutations against each other.
-  let envDominanceRef ← IO.mkRef ({} : Std.HashMap (List Name) Score)
-
   -- Helper: score an ordering via processChoice → ScheduleSteps → bundle.
   -- On-demand: derives unknown deps before scoring.
   let scoreComponentOrdering := fun (env : List Name) (envSet : Std.HashSet Name)
-      (ordering : List (HypothesisExpr × List (List Name)))
-      (sccSize : Nat) => do
-    let (compSched, compEnv, _) ← processOrdering ordering env envSet
+      (ordering : List (HypothesisExpr × List (List Name))) => do
+    let (compSched, _, _) ← processOrdering ordering env envSet
     let typedSteps := compSched.map (typePreScheduleStep nameTypeMap)
     let schedSteps ← (typedSteps.flatMapM (preScheduleStepToScheduleStep ctorName)).run scheduleEnv
     -- On-demand dep derivation
@@ -1412,19 +1403,6 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
       | none =>
         let stepScores ← schedSteps.mapM fun step => bundle.stepScorer key memoState inputVarSet step
         pure (bundle.scheduleScorer stepScores)
-    -- Dominance check: only at leaves (complete component orderings)
-    if ordering.length == sccSize then
-      let envKey := compEnv.eraseDups |>.mergeSort (fun a b => compare a b |>.isLE)
-      let envDom ← envDominanceRef.get
-      match envDom[envKey]? with
-      | some prevBest =>
-        if bundle.isBetter prevBest score then
-          return bundle.worstScore
-      | none => pure ()
-      envDominanceRef.modify fun m =>
-        match m[envKey]? with
-        | some prev => if bundle.isBetter score prev then m.insert envKey score else m
-        | none => m.insert envKey score
     return score
 
   -- 4. Process SCC components sequentially using minTreePruningM per component
@@ -1432,9 +1410,8 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
   let mut accEnv : List Name := fixedVars
   let mut accEnvSet : Std.HashSet Name := Std.HashSet.ofList fixedVars
 
-  for (sccGroup, tree) in componentTrees do
+  for (_sccGroup, tree) in componentTrees do
     if ← done.get then break
-    let sccSize := sccGroup.length
     -- Use minTreePruningM to find the best ordering for this component
     let componentDone ← IO.mkRef false
     let componentBestRef ← IO.mkRef (none : Option (List (PreScheduleStep HypothesisExpr Name) × List Name × Std.HashSet Name × Score))
@@ -1442,7 +1419,7 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
     let envSnapshot := accEnv
     let envSetSnapshot := accEnvSet
 
-    let _ ← SearchTree.minTreePruningM tree (scoreComponentOrdering envSnapshot envSetSnapshot · sccSize)
+    let _ ← SearchTree.minTreePruningM tree (scoreComponentOrdering envSnapshot envSetSnapshot)
       bundle.isBetter componentWorst componentDone
       fun (ordering, score) currentBest => do
         let c ← countRef.get

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -801,7 +801,6 @@ private def enumSchedulesChunked {α v} [BEq v] [Hashable v] (vars : List v) (ma
           l.any (fun v => envSet.contains v && !matchableSet.contains v)
           || l.all matchableSet.contains)
 
-      let _ := 0 -- placeholder for trace
       let (out,bound) ← subsetsAndComplements all_unbound_output_indices
       if out.length > 1 || (out.isEmpty && !bound.isEmpty) then .lnil else
 

--- a/Specimen/DeriveSchedules.lean
+++ b/Specimen/DeriveSchedules.lean
@@ -801,6 +801,7 @@ private def enumSchedulesChunked {α v} [BEq v] [Hashable v] (vars : List v) (ma
           l.any (fun v => envSet.contains v && !matchableSet.contains v)
           || l.all matchableSet.contains)
 
+      let _ := 0 -- placeholder for trace
       let (out,bound) ← subsetsAndComplements all_unbound_output_indices
       if out.length > 1 || (out.isEmpty && !bound.isEmpty) then .lnil else
 
@@ -1406,15 +1407,19 @@ partial def searchBestScheduleM (ctorName : Name) (vars : List TypedVar)
           unless m.contains depKey do deriveDep depKey
     -- Score
     let memoState ← memo.get
-    let stepScores ← schedSteps.mapM fun step => bundle.stepScorer key memoState inputVarSet step
-    let score := bundle.scheduleScorer stepScores
+    let score ← match bundle.wholeScheduleScorer with
+      | some wss => wss key memoState inputVarSet schedSteps
+      | none =>
+        let stepScores ← schedSteps.mapM fun step => bundle.stepScorer key memoState inputVarSet step
+        pure (bundle.scheduleScorer stepScores)
     -- Dominance check: only at leaves (complete component orderings)
     if ordering.length == sccSize then
       let envKey := compEnv.eraseDups |>.mergeSort (fun a b => compare a b |>.isLE)
       let envDom ← envDominanceRef.get
       match envDom[envKey]? with
       | some prevBest =>
-        if bundle.isBetter prevBest score then return bundle.worstScore
+        if bundle.isBetter prevBest score then
+          return bundle.worstScore
       | none => pure ()
       envDominanceRef.modify fun m =>
         match m[envKey]? with

--- a/Specimen/Idents.lean
+++ b/Specimen/Idents.lean
@@ -31,8 +31,6 @@ def negOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "negOpt"
 /-- Ident for `GeneratorCombinators.backtrack`. -/
 def genBacktrackFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "backtrack"
 
-/-- Ident for `Scoring.ctorWeight`. -/
-def ctorWeightFn : Ident := mkIdent $ Name.mkStr2 "Scoring" "ctorWeight"
 
 /-- Ident for the `DecOpt.checkerBacktrack` checker combinator (see `DecOpt.lean`) -/
 def checkerBacktrackFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "checkerBacktrack"

--- a/Specimen/Idents.lean
+++ b/Specimen/Idents.lean
@@ -31,6 +31,9 @@ def negOptFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "negOpt"
 /-- Ident for `GeneratorCombinators.backtrack`. -/
 def genBacktrackFn : Ident := mkIdent $ Name.mkStr2 "GeneratorCombinators" "backtrack"
 
+/-- Ident for `Scoring.ctorWeight`. -/
+def ctorWeightFn : Ident := mkIdent $ Name.mkStr2 "Scoring" "ctorWeight"
+
 /-- Ident for the `DecOpt.checkerBacktrack` checker combinator (see `DecOpt.lean`) -/
 def checkerBacktrackFn : Ident := mkIdent $ Name.mkStr2 "DecOpt" "checkerBacktrack"
 

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -193,7 +193,9 @@ partial def mexpToConstructorExpr (m : MExp) : Option ConstructorExpr :=
 
 /-- `MExp` representation of a recursive function call,
     where `f` is the function name, `fuelPrimeName` is the name for `fuel'`,
-    `sizeExpr` is the size budget passed to the recursive call, and `args` are the input arguments -/
+    `sizeExpr` is the size budget expression passed to the recursive call (an `MExp` rather
+    than a bare `Name` because it may be `size' / N` when the constructor has N size-consuming
+    calls — see `countSizeConsumingCalls`), and `args` are the input arguments -/
 def recCall (f : Name) (fuelPrimeName : Name) (sizeExpr : MExp) (args : List ConstructorExpr) : MExp :=
   .MApp .allowImplicit (.MId f) $
     [.MId fuelPrimeName, .MId `initSize, sizeExpr] ++ (constructorExprToMExp .allExplicit <$> args)
@@ -434,7 +436,11 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
     let typedVars := List.map (nameAndConstructorExprToTypedVar) varsTys
     match prod with
     | Source.NonRec hypExpr => do
-      -- If the dep targets the same inductive, use split size; otherwise full budget
+      -- Same-inductive deps share the split budget: since fuel (not size) guarantees
+      -- termination, we can split size flexibly, and calls that construct the target
+      -- output (even non-recursively, e.g. a different mode of the same relation)
+      -- should share the budget rather than getting the full allocation meant for
+      -- independent dependencies.
       let fuel := if hypExpr.1 == targetInductive then sizeExpr else defFuel
       let producer ← constrainedProducer ps varsTys (hypothesisExprToMExp hypExpr) fuel
       pure $ .MBind monadSort producer typedVars k
@@ -445,7 +451,11 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
     let checker :=
       match src with
       | Source.NonRec hypExpr =>
-        -- If the dep targets the same inductive, use split size; otherwise full budget
+        -- Same-inductive deps share the split budget: since fuel (not size) guarantees
+      -- termination, we can split size flexibly, and calls that construct the target
+      -- output (even non-recursively, e.g. a different mode of the same relation)
+      -- should share the budget rather than getting the full allocation meant for
+      -- independent dependencies.
         let fuel := if hypExpr.1 == targetInductive then sizeExpr else defFuel
         decOptChecker (hypothesisExprToMExp hypExpr) fuel
       | Source.Rec f args | Source.MutRec f args =>

--- a/Specimen/MExp.lean
+++ b/Specimen/MExp.lean
@@ -193,10 +193,10 @@ partial def mexpToConstructorExpr (m : MExp) : Option ConstructorExpr :=
 
 /-- `MExp` representation of a recursive function call,
     where `f` is the function name, `fuelPrimeName` is the name for `fuel'`,
-    `sizePrimeName` is for `size'`, and `args` are the input arguments -/
-def recCall (f : Name) (fuelPrimeName : Name) (sizePrimeName : Name) (args : List ConstructorExpr) : MExp :=
+    `sizeExpr` is the size budget passed to the recursive call, and `args` are the input arguments -/
+def recCall (f : Name) (fuelPrimeName : Name) (sizeExpr : MExp) (args : List ConstructorExpr) : MExp :=
   .MApp .allowImplicit (.MId f) $
-    [.MId fuelPrimeName, .MId `initSize, .MId sizePrimeName] ++ (constructorExprToMExp .allExplicit <$> args)
+    [.MId fuelPrimeName, .MId `initSize, sizeExpr] ++ (constructorExprToMExp .allExplicit <$> args)
 
 /-- Converts a `HypothesisExpr` to an `MExp` -/
 def hypothesisExprToMExp (hypExpr : HypothesisExpr) : MExp :=
@@ -416,7 +416,7 @@ private def nameAndConstructorExprToTypedVar (v : Name × Option ConstructorExpr
       supplied to the generator/enumerator/checker we're deriving
 -/
 
-def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) (fuelPrimeName : Name) (sizePrimeName : Name) : CompileScheduleM MExp :=
+def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (outputType : Expr) (fuelPrimeName : Name) (sizeExpr : MExp) (targetInductive : Name) : CompileScheduleM MExp :=
   match step with
   | .Unconstrained v src prodSort => do
     let monadSort := prodSortToMonadSort prodSort
@@ -427,25 +427,29 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
       let producer ← unconstrainedProducer prodSort ty
       pure $ .MBind monadSort producer [⟨v,tyExpr⟩] k
     | Source.Rec f args | Source.MutRec f args =>
-      pure $ .MBind monadSort (recCall f fuelPrimeName sizePrimeName args) [⟨v, outputType⟩] k
+      pure $ .MBind monadSort (recCall f fuelPrimeName sizeExpr args) [⟨v, outputType⟩] k
 
   | .SuchThat varsTys prod ps => do
     let monadSort := prodSortToOptionTMonadSort ps
     let typedVars := List.map (nameAndConstructorExprToTypedVar) varsTys
     match prod with
     | Source.NonRec hypExpr => do
-      let producer ← constrainedProducer ps varsTys (hypothesisExprToMExp hypExpr) defFuel
+      -- If the dep targets the same inductive, use split size; otherwise full budget
+      let fuel := if hypExpr.1 == targetInductive then sizeExpr else defFuel
+      let producer ← constrainedProducer ps varsTys (hypothesisExprToMExp hypExpr) fuel
       pure $ .MBind monadSort producer typedVars k
     | Source.Rec f args | Source.MutRec f args =>
-      pure $ .MBind monadSort (recCall f fuelPrimeName sizePrimeName args) typedVars k
+      pure $ .MBind monadSort (recCall f fuelPrimeName sizeExpr args) typedVars k
   | .Check src polarity =>
 
     let checker :=
       match src with
       | Source.NonRec hypExpr =>
-        decOptChecker (hypothesisExprToMExp hypExpr) defFuel
+        -- If the dep targets the same inductive, use split size; otherwise full budget
+        let fuel := if hypExpr.1 == targetInductive then sizeExpr else defFuel
+        decOptChecker (hypothesisExprToMExp hypExpr) fuel
       | Source.Rec f args | Source.MutRec f args =>
-        recCall f fuelPrimeName sizePrimeName args
+        recCall f fuelPrimeName sizeExpr args
 
     let checker :=
       if polarity then checker
@@ -459,9 +463,16 @@ def scheduleStepToMExp (step : ScheduleStep) (defFuel : MExp) (k : MExp) (output
     which acts as the conclusion of the schedule) to an `MExp`.
     - `mfuel` and `defFuel` are auxiliary `MExp`s representing the fuel
       for the function we are deriving (these correspond to `size` and `initSize`
-      in the QuickChick code for the derived functions) -/
-def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recType : Expr) (fuelPrimeName : Name := `fuel') (sizePrimeName : Name := `size') : CompileScheduleM MExp :=
+      in the QuickChick code for the derived functions)
+    - `targetInductive` is the inductive we're generating for (used to detect same-type deps) -/
+def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recType : Expr) (fuelPrimeName : Name := `fuel') (sizePrimeName : Name := `size') (targetInductive : Name := `_unknown) : CompileScheduleM MExp :=
   let (scheduleSteps, scheduleSort) := schedule
+  -- Compute the size expression: split budget across all size-consuming calls
+  -- (self-recursive, mutual, and non-recursive calls to the same inductive)
+  let numSizeCalls := Schedules.countSizeConsumingCalls targetInductive scheduleSteps
+  let sizeExpr : MExp :=
+    if numSizeCalls ≤ 1 then .MId sizePrimeName
+    else .MApp .allExplicit (.MConst ``Nat.div) [.MId sizePrimeName, .MLit (.natVal numSizeCalls)]
   -- Determine the *epilogue* of the schedule (i.e. what happens after we
   -- have finished executing all the `scheduleStep`s)
   let epilogue :=
@@ -486,5 +497,5 @@ def scheduleToMExp (schedule : Schedule) (mfuel : MExp) (defFuel : MExp) (recTyp
   -- Fold over the `scheduleSteps` and convert each of them to a functional `MExp`
   -- Note that the fold composes the `MExp`, and we use `foldr` since
   -- we want the `epilogue` to be the base-case of the fold
-  List.foldrM (fun step acc => scheduleStepToMExp step defFuel acc recType fuelPrimeName sizePrimeName)
+  List.foldrM (fun step acc => scheduleStepToMExp step defFuel acc recType fuelPrimeName sizeExpr targetInductive)
     epilogue scheduleSteps

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -617,4 +617,20 @@ def scheduleUsesMutualCall (steps : List ScheduleStep) : Bool :=
     | .Check (.MutRec ..) _ => true
     | _ => false
 
+/-- Count how many size-consuming calls appear in a constructor's schedule steps.
+    Includes self-recursive, mutual-recursive, AND non-recursive calls to the same
+    inductive (any mode), since all produce values of the same type and should share
+    the size budget. Used for Haskell-style budget splitting: each gets size/count. -/
+def countSizeConsumingCalls (targetInductive : Name) (steps : List ScheduleStep) : Nat :=
+  let isSameInductive (src : Source) : Bool :=
+    match src with
+    | .Rec .. | .MutRec .. => true
+    | .NonRec (indName, _) => indName == targetInductive
+  steps.foldl (fun acc step =>
+    match step with
+    | .Unconstrained _ src _ => if isSameInductive src then acc + 1 else acc
+    | .SuchThat _ src _ => if isSameInductive src then acc + 1 else acc
+    | .Check src _ => if isSameInductive src then acc + 1 else acc
+    | _ => acc) 0
+
 end Schedules

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -620,7 +620,14 @@ def scheduleUsesMutualCall (steps : List ScheduleStep) : Bool :=
 /-- Count how many size-consuming calls appear in a constructor's schedule steps.
     Includes self-recursive, mutual-recursive, AND non-recursive calls to the same
     inductive (any mode), since all produce values of the same type and should share
-    the size budget. Used for Haskell-style budget splitting: each gets size/count. -/
+    the size budget. Used for Haskell QuickCheck-style budget splitting: each child
+    gets `size / count`. See the "Generating Recursive Data Types" section of the
+    QuickCheck manual (www.cse.chalmers.se/~rjmh/QuickCheck/manual_body.html), where a
+    binary tree generator passes `n \`div\` 2` to each child so that size bounds the total
+    node count. We generalize beyond direct recursion: mutually recursive calls and
+    non-recursive calls to the same inductive (with a different mode) also consume the
+    budget, since they still use fuel to construct the target output rather than an
+    independent dependency. -/
 def countSizeConsumingCalls (targetInductive : Name) (steps : List ScheduleStep) : Nat :=
   let isSameInductive (src : Source) : Bool :=
     match src with

--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -40,6 +40,23 @@ namespace Scoring
 
 open Lean Meta Schedules
 
+def ctorWeight (density checkSpeed passLikelihood varDeps : Nat)
+    (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+  let qualityBase := match density with
+    | 0 => 4
+    | 1 => 3
+    | 2 => 2
+    | _ => 1
+  let speedPenalty := min 1 (checkSpeed / 2)
+  let likePenalty := min 1 (passLikelihood / 2)
+  let depPenalty := min 1 (varDeps / 4)
+  let quality := max 1 (qualityBase - speedPenalty - likePenalty - depPenalty)
+  if isRec then
+    if size == 0 then 1
+    else max 1 (numBase * size / max 1 numRec) * quality
+  else
+    quality
+
 ----------------------------------------------
 -- Core typeclass
 ----------------------------------------------
@@ -62,6 +79,12 @@ class Scorable (S : Type) where
   /-- Must be worse than any real schedule under `isBetter`. -/
   worst : S
   badness : S → Float
+  /-- Extract (density, checkSpeed, passLikelihood, varDeps) for runtime ctorWeight.
+      Default maps badness to an approximate density. -/
+  weightArgs : S → Array Nat := fun s =>
+    let b := badness s
+    let d := if b < 0.25 then 0 else if b < 0.5 then 1 else if b < 0.75 then 2 else 3
+    #[d, 0, 0, 0]
 
 ----------------------------------------------
 -- Scorer function types (parameterized by score type)
@@ -72,7 +95,7 @@ class Scorable (S : Type) where
     - The dependency memo (for looking up sub-relation scores)
     - The set of input variables (fixed at schedule start, NOT generated)
     - The step itself -/
-abbrev StepScorer (S : Type) := SpecKey → Std.HashMap SpecKey MemoEntry → Std.HashSet Name → ScheduleStep → S
+abbrev StepScorer (S : Type) := SpecKey → Std.HashMap SpecKey MemoEntry → Std.HashSet Name → ScheduleStep → MetaM S
 
 /-- Combines a list of step scores into a schedule-level score. -/
 abbrev ScheduleScorer (S : Type) := List S → S
@@ -94,7 +117,7 @@ abbrev InductiveAggregator (S : Type) := List S → S
 ----------------------------------------------
 
 /-- A resolved step scorer that produces type-erased scores. -/
-abbrev ResolvedStepScorer := SpecKey → Std.HashMap SpecKey MemoEntry → Std.HashSet Name → ScheduleStep → Score
+abbrev ResolvedStepScorer := SpecKey → Std.HashMap SpecKey MemoEntry → Std.HashSet Name → ScheduleStep → MetaM Score
 
 /-- A resolved schedule scorer. -/
 abbrev ResolvedScheduleScorer := List Score → Score
@@ -162,7 +185,7 @@ instance : Inhabited Score where default := Score.wrap ({} : DefaultScore)
 
 /-- Wrap a typed scorer into a ResolvedStepScorer. -/
 def wrapStepScorer [Inhabited S] [TypeName S] [Repr S] (f : StepScorer S) : ResolvedStepScorer :=
-  fun key memo inputVars step => Score.wrap (f key memo inputVars step)
+  fun key memo inputVars step => return Score.wrap (← f key memo inputVars step)
 
 /-- Wrap a typed schedule scorer into a ResolvedScheduleScorer. -/
 def wrapScheduleScorer [Inhabited S] [TypeName S] [Repr S] (f : ScheduleScorer S) : ResolvedScheduleScorer :=
@@ -216,6 +239,8 @@ structure ScorerBundle where
   worstScore : Score
   /-- Map score to [0,1] for HSL color display (0 = best, 1 = worst). -/
   scoreBadness : Score → Float
+  /-- Extract (density, checkSpeed, passLikelihood, varDeps) as Nats for runtime ctorWeight. -/
+  ctorWeightArgs : Score → Array Nat
   pruneStrategy : PruneStrategy := .usePrimary
 
 /-- Build a complete ScorerBundle from typed scorers. -/
@@ -237,12 +262,13 @@ def mkScorerBundle [Inhabited S] [TypeName S] [Repr S] [Scorable S]
     penaltyScore := Score.wrap (Scorable.uncoveredPenalty : S)
     worstScore := Score.wrap (Scorable.worst : S)
     scoreBadness := fun s => Scorable.badness (Score.unwrap S s)
+    ctorWeightArgs := fun s => Scorable.weightArgs (Score.unwrap S s)
     pruneStrategy := .usePrimary }
 
 instance : Inhabited ScorerBundle where
   default := {
     scoreTypeName := `Scoring.DefaultScore
-    stepScorer := fun _ _ _ => default
+    stepScorer := fun _ _ _ _ => return default
     scheduleScorer := fun _ => default
     leafAggregator := fun _ => default
     inductiveAggregator := fun _ => default
@@ -253,6 +279,7 @@ instance : Inhabited ScorerBundle where
     penaltyScore := default
     worstScore := default
     scoreBadness := fun _ => 0.0
+    ctorWeightArgs := fun _ => #[1, 0, 0, 0]
     pruneStrategy := .noPruning
   }
 
@@ -302,7 +329,7 @@ def getActiveScorerBundle : MetaM ScorerBundle := do
 -- Built-in: default strategy (sum of best)
 ----------------------------------------------
 
-def defaultStepScorer : StepScorer DefaultScore := fun _key memo _inputVars step =>
+def defaultStepScorer : StepScorer DefaultScore := fun _key memo _inputVars step => do
   let baseScore : DefaultScore := match step with
     | .Check .. => { checks := 1, length := 1 }
     | .Unconstrained .. => { length := 1, unconstrained := 1 }
@@ -321,7 +348,7 @@ def defaultStepScorer : StepScorer DefaultScore := fun _key memo _inputVars step
             unconstrained := acc.unconstrained + ds.unconstrained }
         | _ => acc
       else acc) {}
-  Scorable.combine baseScore depCost
+  return Scorable.combine baseScore depCost
 
 def defaultScheduleScorer : ScheduleScorer DefaultScore := fun stepScores =>
   stepScores.foldl Scorable.combine Scorable.empty
@@ -373,8 +400,8 @@ instance : Scorable WorstLeafScore where
       let uncRatio := Float.ofNat s.unconstrained / Float.ofNat s.length
       min 1.0 (checkRatio * 2.0 + uncRatio * 0.5)
 
-def worstLeafStepScorer : StepScorer WorstLeafScore := fun _key _memo _inputVars step =>
-  match step with
+def worstLeafStepScorer : StepScorer WorstLeafScore := fun _key _memo _inputVars step => do
+  return match step with
   | .Check .. => { checks := 1, length := 1 }
   | .Unconstrained .. => { length := 1, unconstrained := 1 }
   | _ => { length := 1 }
@@ -473,9 +500,9 @@ private def countGeneratedVarDeps (inputVars : Std.HashSet Name) (src : Source) 
     - Match → Backtracking, 0 deps
     - SuchThat → dep's density from memo, #generated-var deps
     varDeps counts source args that were generated (not original inputs). -/
-def densityStepScorer : StepScorer DensityScore := fun key memo inputVars step =>
+def densityStepScorer : StepScorer DensityScore := fun key memo inputVars step => do
   let isChecker := key.deriveSort == .Checker || key.deriveSort == .Enumerator
-  match step with
+  return match step with
   | .Unconstrained .. => { density := .Total, varDeps := 0, forChecker := isChecker }
   | .Check src _ => { density := .Checking, varDeps := countGeneratedVarDeps inputVars src, forChecker := isChecker }
   | .Match .. => { density := .Backtracking, varDeps := 0, forChecker := isChecker }
@@ -543,8 +570,8 @@ instance : Scorable UniformDensityScore where
     let depPenalty := min 0.2 (s.varDeps.toFloat * 0.05)
     min 1.0 (level + depPenalty)
 
-def uniformDensityStepScorer : StepScorer UniformDensityScore := fun _key memo inputVars step =>
-  match step with
+def uniformDensityStepScorer : StepScorer UniformDensityScore := fun _key memo inputVars step => do
+  return match step with
   | .Unconstrained .. => { density := .Total, varDeps := 0 }
   | .Check src _ => { density := .Checking, varDeps := countGeneratedVarDeps inputVars src }
   | .Match .. => { density := .Backtracking, varDeps := 0 }
@@ -577,5 +604,489 @@ def uniformDensityInductiveAggregator : InductiveAggregator UniformDensityScore 
 
 initialize registerScoringBundle (mkScorerBundle `Scoring.UniformDensityScore
   uniformDensityStepScorer uniformDensityScheduleScorer uniformDensityLeafAggregator uniformDensityInductiveAggregator)
+
+----------------------------------------------
+-- Built-in: graded uniform density (two-axis check severity)
+----------------------------------------------
+
+inductive CheckSpeed
+  | NotACheck
+  | Decidable
+  | Moderate
+  | Expensive
+  | Recursive
+  deriving Repr, BEq, Inhabited
+
+namespace CheckSpeed
+
+def toNat : CheckSpeed → Nat
+  | .NotACheck => 0
+  | .Decidable => 1
+  | .Moderate => 2
+  | .Expensive => 3
+  | .Recursive => 4
+
+instance : Ord CheckSpeed where
+  compare a b := compare a.toNat b.toNat
+
+def max (a b : CheckSpeed) : CheckSpeed := if a.toNat ≥ b.toNat then a else b
+
+end CheckSpeed
+
+inductive PassLikelihood
+  | Certain
+  | Likely
+  | Moderate
+  | Unlikely
+  | Desperate
+  deriving Repr, BEq, Inhabited
+
+namespace PassLikelihood
+
+def toNat : PassLikelihood → Nat
+  | .Certain => 0
+  | .Likely => 1
+  | .Moderate => 2
+  | .Unlikely => 3
+  | .Desperate => 4
+
+instance : Ord PassLikelihood where
+  compare a b := compare a.toNat b.toNat
+
+def max (a b : PassLikelihood) : PassLikelihood := if a.toNat ≥ b.toNat then a else b
+
+end PassLikelihood
+
+structure GradedUniformDensityScore where
+  density        : Density := .Total
+  checkSpeed     : CheckSpeed := .NotACheck
+  passLikelihood : PassLikelihood := .Certain
+  varDeps        : Nat := 0
+  deriving Repr, BEq, Inhabited
+
+deriving instance TypeName for GradedUniformDensityScore
+
+instance : Ord GradedUniformDensityScore where
+  compare a b :=
+    match compare a.density.toNat b.density.toNat with
+    | .eq => match compare a.checkSpeed.toNat b.checkSpeed.toNat with
+      | .eq => match compare a.passLikelihood.toNat b.passLikelihood.toNat with
+        | .eq => compare a.varDeps b.varDeps
+        | r => r
+      | r => r
+    | r => r
+
+instance : LT GradedUniformDensityScore := ltOfOrd
+
+instance : Scorable GradedUniformDensityScore where
+  empty := {}
+  combine a b :=
+    { density := Density.max a.density b.density
+      checkSpeed := CheckSpeed.max a.checkSpeed b.checkSpeed
+      passLikelihood := PassLikelihood.max a.passLikelihood b.passLikelihood
+      varDeps := a.varDeps + b.varDeps }
+  isBetter a b := a < b
+  bestOf scores := scores.foldl (fun acc s => if s < acc then s else acc) (scores.headD {})
+  uncoveredPenalty := { density := .Partial, varDeps := 0 }
+  worst := { density := .Checking, checkSpeed := .Recursive, passLikelihood := .Desperate, varDeps := 1000 }
+  badness s :=
+    let varDepPenalty := min 0.05 (s.varDeps.toFloat * 0.01)
+    if s.density != .Checking then
+      let level := s.density.toNat.toFloat / 4.0
+      min 1.0 (level + varDepPenalty)
+    else
+      let speedVal := match s.checkSpeed with
+        | .NotACheck => 0.0 | .Decidable => 0.0 | .Moderate => 0.33
+        | .Expensive => 0.66 | .Recursive => 1.0
+      let likelVal := match s.passLikelihood with
+        | .Certain => 0.0 | .Likely => 0.0 | .Moderate => 0.33
+        | .Unlikely => 0.66 | .Desperate => 1.0
+      let severity := max speedVal likelVal * 0.7 + min speedVal likelVal * 0.3
+      min 1.0 (0.75 + severity * 0.25 + varDepPenalty)
+  weightArgs s := #[s.density.toNat, s.checkSpeed.toNat, s.passLikelihood.toNat, s.varDeps]
+
+private def estimateTypeCtorCount (indName : Name) : MetaM (Option Nat) := do
+  let env ← getEnv
+  match env.find? indName with
+  | some (.inductInfo val) =>
+    let isRecursive ← val.ctors.anyM fun c => do
+      let cinfo ← getConstInfo c
+      return cinfo.type.find? (fun e => e == .const indName []) |>.isSome
+    if isRecursive then return none
+    else return some val.ctors.length
+  | _ => return none
+
+private def extractEqTypeName : List ConstructorExpr → Option Name
+  | [.Ctor n _, _, _] | [.TyCtor n _, _, _] => some n
+  | _ => none
+
+private def classifyCheckSpeed (memo : Std.HashMap SpecKey MemoEntry) (key : SpecKey)
+    (src : Source) (varDeps : Nat) : CheckSpeed :=
+  match src with
+  | .Rec .. | .MutRec .. => .Recursive
+  | .NonRec (indName, _args) =>
+    let depKey : SpecKey := { inductiveName := indName, outputIndices := [], deriveSort := .Checker }
+    let depDensity := if depKey == key then Density.Checking
+      else match memo[depKey]? with
+        | some (.done depSched) => (Score.unwrap GradedUniformDensityScore depSched.score).density
+        | _ => .Partial
+    let isChecker := key.deriveSort == .Checker || key.deriveSort == .Enumerator
+    if isChecker then
+      match varDeps with
+      | 0 => match depDensity with
+        | .Total | .Partial => .Decidable
+        | .Backtracking => .Moderate
+        | .Checking => .Expensive
+      | 1 => match depDensity with
+        | .Total | .Partial => .Moderate
+        | _ => .Expensive
+      | 2 | 3 => .Expensive
+      | _ => .Recursive
+    else
+      match depDensity with
+      | .Total | .Partial => .Decidable
+      | .Backtracking => .Moderate
+      | .Checking => .Expensive
+
+private def classifyPassLikelihood (inputVars : Std.HashSet Name) (key : SpecKey)
+    (src : Source) (polarity : Bool) (varDeps : Nat) : MetaM PassLikelihood := do
+  if varDeps == 0 then return .Certain
+  let isChecker := key.deriveSort == .Checker || key.deriveSort == .Enumerator
+  match src with
+  | .Rec .. | .MutRec .. =>
+    if isChecker then return .Moderate
+    else return .Desperate
+  | .NonRec (indName, args) =>
+    let arity := args.length
+    if indName == ``Eq then
+      let eqArgs := args.flatMap varsInConstructorExpr
+      let genVars := eqArgs.filter (!inputVars.contains ·)
+      if genVars.isEmpty then return .Certain
+      let ctorCount ← match extractEqTypeName args with
+        | some typeName => estimateTypeCtorCount typeName
+        | none => pure none
+      if polarity then
+        match ctorCount with
+        | some n => if n ≤ 2 then return .Unlikely else return .Desperate
+        | none => return .Desperate
+      else
+        match ctorCount with
+        | some n => if n ≤ 2 then return .Moderate else return .Likely
+        | none => return .Likely
+    if isChecker then
+      return .Certain
+    else
+      if !polarity && varDeps ≤ 1 then return .Likely
+      if varDeps == 1 && arity ≤ 3 then return .Likely
+      if varDeps ≤ 3 then return .Moderate
+      return .Unlikely
+
+def gradedStepScorer : StepScorer GradedUniformDensityScore := fun key memo inputVars step => do
+  match step with
+  | .Unconstrained .. => return { density := .Total }
+  | .Match .. => return { density := .Backtracking }
+  | .Check src polarity =>
+    let varDeps := countGeneratedVarDeps inputVars src
+    let speed := classifyCheckSpeed memo key src varDeps
+    let likelihood ← classifyPassLikelihood inputVars key src polarity varDeps
+    return { density := .Checking, checkSpeed := speed, passLikelihood := likelihood, varDeps := varDeps }
+  | .SuchThat outputs src prodSort =>
+    let outputNames := Std.HashSet.ofList (outputs.map (·.1))
+    let varDeps := countGeneratedVarDeps (inputVars.union outputNames) src
+    let depDensity : Density := match src with
+      | .Rec .. => .Partial
+      | .MutRec .. => .Partial
+      | .NonRec (indName, args) =>
+        let outputIdxs := outputs.filterMap fun (n, _) =>
+          args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+        let depDeriveSort := match prodSort with
+          | .Enumerator => DeriveSort.Enumerator
+          | .Generator => DeriveSort.Generator
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+        if depKey == key then .Partial
+        else match memo[depKey]? with
+          | some (.done depSched) => (Score.unwrap GradedUniformDensityScore depSched.score).density
+          | _ => .Partial
+    return { density := depDensity, varDeps := varDeps }
+
+def gradedScheduleScorer : ScheduleScorer GradedUniformDensityScore := fun stepScores =>
+  stepScores.foldl Scorable.combine Scorable.empty
+
+def gradedLeafAggregator : LeafAggregator GradedUniformDensityScore := fun ctors =>
+  match ctors with
+  | [] => Scorable.uncoveredPenalty
+  | _ => Scorable.bestOf (ctors.map Prod.snd)
+
+def gradedInductiveAggregator : InductiveAggregator GradedUniformDensityScore := fun leafScores =>
+  leafScores.foldl Scorable.combine Scorable.empty
+
+initialize registerScoringBundle (mkScorerBundle `Scoring.GradedUniformDensityScore
+  gradedStepScorer gradedScheduleScorer gradedLeafAggregator gradedInductiveAggregator)
+
+----------------------------------------------
+-- BoundedGradedScore: refines GradedUniformDensityScore
+-- with a Boundedness field that distinguishes finite from
+-- potentially-infinite enumeration in SuchThat steps.
+----------------------------------------------
+
+inductive Boundedness
+  | Finite      -- dep has only base cases (deterministic / bounded enumeration)
+  | Bounded     -- dep has rec cases but is structurally decreasing on known input
+  | Unbounded   -- dep has rec cases on unknown/generated input (potentially infinite)
+  deriving Repr, BEq, Inhabited
+
+namespace Boundedness
+def toNat : Boundedness → Nat
+  | .Finite => 0
+  | .Bounded => 1
+  | .Unbounded => 2
+
+def max (a b : Boundedness) : Boundedness :=
+  if a.toNat ≥ b.toNat then a else b
+end Boundedness
+
+structure BoundedGradedScore where
+  density        : Density := .Total
+  boundedness    : Boundedness := .Finite
+  checkSpeed     : CheckSpeed := .NotACheck
+  passLikelihood : PassLikelihood := .Certain
+  varDeps        : Nat := 0
+  deriving Repr, BEq, Inhabited
+
+deriving instance TypeName for BoundedGradedScore
+
+instance : Ord BoundedGradedScore where
+  compare a b :=
+    match compare a.density.toNat b.density.toNat with
+    | .eq => match compare a.boundedness.toNat b.boundedness.toNat with
+      | .eq => match compare a.checkSpeed.toNat b.checkSpeed.toNat with
+        | .eq => match compare a.passLikelihood.toNat b.passLikelihood.toNat with
+          | .eq => compare a.varDeps b.varDeps
+          | r => r
+        | r => r
+      | r => r
+    | r => r
+
+instance : LT BoundedGradedScore := ltOfOrd
+
+instance : Scorable BoundedGradedScore where
+  empty := {}
+  combine a b :=
+    { density := Density.max a.density b.density
+      boundedness := Boundedness.max a.boundedness b.boundedness
+      checkSpeed := CheckSpeed.max a.checkSpeed b.checkSpeed
+      passLikelihood := PassLikelihood.max a.passLikelihood b.passLikelihood
+      varDeps := a.varDeps + b.varDeps }
+  isBetter a b := a < b
+  bestOf scores := scores.foldl (fun acc s => if s < acc then s else acc) (scores.headD {})
+  uncoveredPenalty := { density := .Checking, boundedness := .Unbounded,
+                        checkSpeed := .Recursive, passLikelihood := .Desperate, varDeps := 1000 }
+  worst := { density := .Checking, boundedness := .Unbounded,
+             checkSpeed := .Recursive, passLikelihood := .Desperate, varDeps := 1000 }
+  badness s :=
+    let d := s.density.toNat.toFloat / 3.0
+    let b := s.boundedness.toNat.toFloat / 2.0
+    let c := s.checkSpeed.toNat.toFloat / 4.0
+    let p := s.passLikelihood.toNat.toFloat / 3.0
+    (d * 0.4 + b * 0.2 + c * 0.2 + p * 0.2)
+
+/-- Extract the `Source.Rec` input args from a schedule's steps (the arguments
+    passed to the recursive call). Returns `none` if no rec call is found. -/
+private def findRecCallInputArgs (steps : List ScheduleStep) : Option (List ConstructorExpr) :=
+  steps.findSome? fun step => match step with
+    | .SuchThat _ (.Rec _ args) _ => some args
+    | .Check (.Rec _ args) _ => some args
+    | .Unconstrained _ (.Rec _ args) _ => some args
+    | _ => none
+
+/-- Classify whether a dep's recursion is structurally decreasing on an input.
+    Inspects the dep's `recSchedules`: if the recursive call passes a different
+    variable at an input position (introduced by a Match step = subterm), it's bounded.
+    If all inputs are unchanged, it's unbounded. -/
+private def classifyBoundednessFromSchedule (depSched : InductiveSchedule) : Boundedness :=
+  if depSched.recSchedules.isEmpty then .Finite
+  else
+    let outputIdxSet := Std.HashSet.ofList depSched.key.outputIndices
+    let inputNames := (List.range depSched.argNames.length).zip depSched.argNames |>.filterMap fun (i, name) =>
+      if outputIdxSet.contains i then none else some name
+    if inputNames.isEmpty then .Unbounded
+    else
+      let allRecDecrease := depSched.recSchedules.all fun (_, (steps, _)) =>
+        match findRecCallInputArgs steps with
+        | none => false
+        | some recArgs =>
+          inputNames.zip recArgs |>.any fun (origName, recArg) =>
+            match recArg with
+            | .Unknown name => name != origName
+            | _ => true
+      if allRecDecrease then .Bounded else .Unbounded
+
+def boundedStepScorer : StepScorer BoundedGradedScore := fun key memo inputVars step => do
+  match step with
+  | .Unconstrained .. => return { density := .Total }
+  | .Match .. => return { density := .Backtracking }
+  | .Check src polarity =>
+    let varDeps := countGeneratedVarDeps inputVars src
+    let speed := classifyCheckSpeed memo key src varDeps
+    let likelihood ← classifyPassLikelihood inputVars key src polarity varDeps
+    return { density := .Checking, checkSpeed := speed, passLikelihood := likelihood, varDeps := varDeps }
+  | .SuchThat outputs src prodSort =>
+    let outputNames := Std.HashSet.ofList (outputs.map (·.1))
+    let varDeps := countGeneratedVarDeps (inputVars.union outputNames) src
+    let depDensity : Density := match src with
+      | .Rec .. => .Partial
+      | .MutRec .. => .Partial
+      | .NonRec (indName, args) =>
+        let outputIdxs := outputs.filterMap fun (n, _) =>
+          args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+        let depDeriveSort := match prodSort with
+          | .Enumerator => DeriveSort.Enumerator
+          | .Generator => DeriveSort.Generator
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+        if depKey == key then .Partial
+        else match memo[depKey]? with
+          | some (.done depSched) => (Score.unwrap BoundedGradedScore depSched.score).density
+          | _ => .Partial
+    let boundedness := match src with
+      | .Rec .. | .MutRec .. => Boundedness.Unbounded
+      | .NonRec (indName, args) =>
+        let outputIdxs := outputs.filterMap fun (n, _) =>
+          args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+        let depDeriveSort := match prodSort with
+          | .Enumerator => DeriveSort.Enumerator
+          | .Generator => DeriveSort.Generator
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+        if depKey == key then .Unbounded
+        else match memo[depKey]? with
+          | some (.done depSched) => classifyBoundednessFromSchedule depSched
+          | _ => .Bounded
+    return { density := depDensity, boundedness := boundedness, varDeps := varDeps }
+
+def boundedScheduleScorer : ScheduleScorer BoundedGradedScore := fun stepScores =>
+  stepScores.foldl Scorable.combine Scorable.empty
+
+def boundedLeafAggregator : LeafAggregator BoundedGradedScore := fun ctors =>
+  match ctors with
+  | [] => Scorable.uncoveredPenalty
+  | _ => Scorable.bestOf (ctors.map Prod.snd)
+
+def boundedInductiveAggregator : InductiveAggregator BoundedGradedScore := fun leafScores =>
+  leafScores.foldl Scorable.combine Scorable.empty
+
+initialize registerScoringBundle (mkScorerBundle `Scoring.BoundedGradedScore
+  boundedStepScorer boundedScheduleScorer boundedLeafAggregator boundedInductiveAggregator)
+
+
+----------------------------------------------
+-- Built-in: InputAwareGradedScore
+-- Like GradedUniformDensityScore but with leaf/inductive aggregation
+-- that penalizes checks whose generated variables overlap with inputs
+-- (i.e. "generate then verify against input" patterns).
+----------------------------------------------
+
+structure InputAwareGradedScore where
+  density        : Density := .Total
+  checkSpeed     : CheckSpeed := .NotACheck
+  passLikelihood : PassLikelihood := .Certain
+  varDeps        : Nat := 0
+  inputCheckDeps : Nat := 0
+  deriving Repr, BEq, Inhabited
+
+deriving instance TypeName for InputAwareGradedScore
+
+instance : Ord InputAwareGradedScore where
+  compare a b :=
+    match compare a.density.toNat b.density.toNat with
+    | .eq => match compare a.inputCheckDeps b.inputCheckDeps with
+      | .eq => match compare a.checkSpeed.toNat b.checkSpeed.toNat with
+        | .eq => match compare a.passLikelihood.toNat b.passLikelihood.toNat with
+          | .eq => compare a.varDeps b.varDeps
+          | r => r
+        | r => r
+      | r => r
+    | r => r
+
+instance : LT InputAwareGradedScore := ltOfOrd
+
+instance : Scorable InputAwareGradedScore where
+  empty := {}
+  combine a b :=
+    { density := Density.max a.density b.density
+      checkSpeed := CheckSpeed.max a.checkSpeed b.checkSpeed
+      passLikelihood := PassLikelihood.max a.passLikelihood b.passLikelihood
+      varDeps := a.varDeps + b.varDeps
+      inputCheckDeps := a.inputCheckDeps + b.inputCheckDeps }
+  isBetter a b := a < b
+  bestOf scores := scores.foldl (fun acc s => if s < acc then s else acc) (scores.headD {})
+  uncoveredPenalty := { density := .Partial, varDeps := 0 }
+  worst := { density := .Checking, checkSpeed := .Recursive, passLikelihood := .Desperate, varDeps := 1000, inputCheckDeps := 100 }
+  badness s :=
+    let varDepPenalty := min 0.05 (s.varDeps.toFloat * 0.01)
+    let inputPenalty := min 0.3 (s.inputCheckDeps.toFloat * 0.1)
+    if s.density != .Checking then
+      let level := s.density.toNat.toFloat / 4.0
+      min 1.0 (level + varDepPenalty + inputPenalty)
+    else
+      let speedVal := match s.checkSpeed with
+        | .NotACheck => 0.0 | .Decidable => 0.0 | .Moderate => 0.33
+        | .Expensive => 0.66 | .Recursive => 1.0
+      let likelVal := match s.passLikelihood with
+        | .Certain => 0.0 | .Likely => 0.0 | .Moderate => 0.33
+        | .Unlikely => 0.66 | .Desperate => 1.0
+      let severity := max speedVal likelVal * 0.7 + min speedVal likelVal * 0.3
+      min 1.0 (0.75 + severity * 0.25 + varDepPenalty + inputPenalty)
+  weightArgs s := #[s.density.toNat, s.checkSpeed.toNat, s.passLikelihood.toNat, s.varDeps]
+
+private def countInputCheckDeps (inputVars : Std.HashSet Name) (src : Source) : Nat :=
+  let allVars := match src with
+    | .NonRec (_, args) => args.flatMap varsInConstructorExpr
+    | .Rec _ args => args.flatMap varsInConstructorExpr
+    | .MutRec _ args => args.flatMap varsInConstructorExpr
+  let inputArgs := allVars.filter inputVars.contains
+  inputArgs.length
+
+def inputAwareStepScorer : StepScorer InputAwareGradedScore := fun key memo inputVars step => do
+  match step with
+  | .Unconstrained .. => return { density := .Total }
+  | .Match .. => return { density := .Backtracking }
+  | .Check src polarity =>
+    let varDeps := countGeneratedVarDeps inputVars src
+    let speed := classifyCheckSpeed memo key src varDeps
+    let likelihood ← classifyPassLikelihood inputVars key src polarity varDeps
+    let inputDeps := if varDeps > 0 then countInputCheckDeps inputVars src else 0
+    return { density := .Checking, checkSpeed := speed, passLikelihood := likelihood, varDeps := varDeps, inputCheckDeps := inputDeps }
+  | .SuchThat outputs src prodSort =>
+    let outputNames := Std.HashSet.ofList (outputs.map (·.1))
+    let varDeps := countGeneratedVarDeps (inputVars.union outputNames) src
+    let depDensity : Density := match src with
+      | .Rec .. => .Partial
+      | .MutRec .. => .Partial
+      | .NonRec (indName, args) =>
+        let outputIdxs := outputs.filterMap fun (n, _) =>
+          args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+        let depDeriveSort := match prodSort with
+          | .Enumerator => DeriveSort.Enumerator
+          | .Generator => DeriveSort.Generator
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+        if depKey == key then .Partial
+        else match memo[depKey]? with
+          | some (.done depSched) => (Score.unwrap InputAwareGradedScore depSched.score).density
+          | _ => .Partial
+    return { density := depDensity, varDeps := varDeps }
+
+def inputAwareScheduleScorer : ScheduleScorer InputAwareGradedScore := fun stepScores =>
+  stepScores.foldl Scorable.combine Scorable.empty
+
+def inputAwareLeafAggregator : LeafAggregator InputAwareGradedScore := fun ctors =>
+  match ctors with
+  | [] => Scorable.uncoveredPenalty
+  | _ => Scorable.bestOf (ctors.map Prod.snd)
+
+def inputAwareInductiveAggregator : InductiveAggregator InputAwareGradedScore := fun leafScores =>
+  leafScores.foldl Scorable.combine Scorable.empty
+
+initialize registerScoringBundle (mkScorerBundle `Scoring.InputAwareGradedScore
+  inputAwareStepScorer inputAwareScheduleScorer inputAwareLeafAggregator inputAwareInductiveAggregator)
+
 
 end Scoring

--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -40,22 +40,102 @@ namespace Scoring
 
 open Lean Meta Schedules
 
-def ctorWeight (density checkSpeed passLikelihood varDeps : Nat)
-    (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
-  let qualityBase := match density with
-    | 0 => 4
-    | 1 => 3
-    | 2 => 2
-    | _ => 1
-  let speedPenalty := min 1 (checkSpeed / 2)
-  let likePenalty := min 1 (passLikelihood / 2)
-  let depPenalty := min 1 (varDeps / 4)
-  let quality := max 1 (qualityBase - speedPenalty - likePenalty - depPenalty)
+----------------------------------------------
+-- Weight function type and registry
+----------------------------------------------
+
+/-- A weight function computes the runtime frequency weight for a constructor.
+    Arguments: (scoreBadness, isRec, size, numBase, numRec).
+    - scoreBadness: per-constructor quality from the active scorer (0.0 = best, 1.0 = worst)
+    - isRec: whether this constructor is recursive
+    - size: current generation size parameter
+    - numBase/numRec: counts of base vs recursive constructors for this inductive -/
+abbrev CtorWeightFn := Float → Bool → Nat → Nat → Nat → Nat
+
+/-- Ignores score; base=1, recursive=numBase*size/numRec. -/
+def defaultCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+  if isRec then
+    if size == 0 then 1
+    else max 1 (numBase * size / max 1 numRec)
+  else 1
+
+/-- QuickChick-style weight: base=1, recursive=size+1. Ignores score. -/
+def quickchickCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
+  if isRec then size + 1 else 1
+
+/-- Flat weight: every constructor gets weight 1. Ignores everything. -/
+def flatCtorWeight (_scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat := 1
+
+/-- Score-aware weight: boosts good constructors (low badness) and deprioritizes
+    recursive ones. Quality maps to 1–4, recursive ctors get an additional size-based
+    penalty so base cases are preferred at small sizes. -/
+def scoreAwareCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+  let quality := if scoreBadness < 0.25 then 4
+    else if scoreBadness < 0.5 then 3
+    else if scoreBadness < 0.75 then 2
+    else 1
   if isRec then
     if size == 0 then 1
     else max 1 (numBase * size / max 1 numRec) * quality
-  else
-    quality
+  else quality
+
+/-- Balanced weight for inductives with many recursive constructors.
+    Controls aggregate P(recursive) ≈ size / (size + 4*numBase) by distributing
+    size across all recursive ctors (so total rec weight ≈ size * quality).
+    Base ctors get a 4x boost so they stay relevant even with many rec branches. -/
+def balancedCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase numRec : Nat) : Nat :=
+  let quality := if scoreBadness < 0.25 then 4
+    else if scoreBadness < 0.5 then 3
+    else if scoreBadness < 0.75 then 2
+    else 1
+  if isRec then
+    if size == 0 then 0
+    else max 1 (size / max 1 numRec) * quality
+  else quality * 4
+
+/-- Quality-only weight: no structural bias, budget splitting handles termination. -/
+def qualityCtorWeight (scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat :=
+  if scoreBadness < 0.25 then 4
+  else if scoreBadness < 0.5 then 3
+  else if scoreBadness < 0.75 then 2
+  else 1
+
+structure WeightFnEntry where
+  name : Name
+  fn : CtorWeightFn
+  leanName : Name
+
+initialize weightFnRegistry : IO.Ref (Array WeightFnEntry) ← IO.mkRef #[]
+
+def registerWeightFn (name : Name) (fn : CtorWeightFn) (leanName : Name) : IO Unit :=
+  weightFnRegistry.modify (·.push { name, fn, leanName })
+
+initialize registerWeightFn `Scoring.defaultCtorWeight defaultCtorWeight ``defaultCtorWeight
+initialize registerWeightFn `Scoring.quickchickCtorWeight quickchickCtorWeight ``quickchickCtorWeight
+initialize registerWeightFn `Scoring.flatCtorWeight flatCtorWeight ``flatCtorWeight
+initialize registerWeightFn `Scoring.scoreAwareCtorWeight scoreAwareCtorWeight ``scoreAwareCtorWeight
+initialize registerWeightFn `Scoring.balancedCtorWeight balancedCtorWeight ``balancedCtorWeight
+initialize registerWeightFn `Scoring.qualityCtorWeight qualityCtorWeight ``qualityCtorWeight
+
+register_option specimen.weightFn : String := {
+  defValue := "Scoring.balancedCtorWeight"
+  descr := "The weight function used for constructor frequency in derived generators."
+}
+
+/-- Get the active weight function name from options. -/
+def getActiveWeightFnName [Monad m] [MonadOptions m] : m Name := do
+  let s : String := Lean.Option.get (← getOptions) specimen.weightFn
+  return s.toName
+
+/-- Resolve the active weight function entry. -/
+def getActiveWeightFn : CoreM WeightFnEntry := do
+  let name ← getActiveWeightFnName
+  let entries ← weightFnRegistry.get
+  match entries.find? (·.name == name) with
+  | some entry => return entry
+  | none => match entries[0]? with
+    | some entry => return entry
+    | none => return { name := `Scoring.balancedCtorWeight, fn := balancedCtorWeight, leanName := ``balancedCtorWeight }
 
 ----------------------------------------------
 -- Core typeclass
@@ -79,12 +159,6 @@ class Scorable (S : Type) where
   /-- Must be worse than any real schedule under `isBetter`. -/
   worst : S
   badness : S → Float
-  /-- Extract (density, checkSpeed, passLikelihood, varDeps) for runtime ctorWeight.
-      Default maps badness to an approximate density. -/
-  weightArgs : S → Array Nat := fun s =>
-    let b := badness s
-    let d := if b < 0.25 then 0 else if b < 0.5 then 1 else if b < 0.75 then 2 else 3
-    #[d, 0, 0, 0]
 
 ----------------------------------------------
 -- Scorer function types (parameterized by score type)
@@ -239,8 +313,6 @@ structure ScorerBundle where
   worstScore : Score
   /-- Map score to [0,1] for HSL color display (0 = best, 1 = worst). -/
   scoreBadness : Score → Float
-  /-- Extract (density, checkSpeed, passLikelihood, varDeps) as Nats for runtime ctorWeight. -/
-  ctorWeightArgs : Score → Array Nat
   pruneStrategy : PruneStrategy := .usePrimary
 
 /-- Build a complete ScorerBundle from typed scorers. -/
@@ -262,7 +334,6 @@ def mkScorerBundle [Inhabited S] [TypeName S] [Repr S] [Scorable S]
     penaltyScore := Score.wrap (Scorable.uncoveredPenalty : S)
     worstScore := Score.wrap (Scorable.worst : S)
     scoreBadness := fun s => Scorable.badness (Score.unwrap S s)
-    ctorWeightArgs := fun s => Scorable.weightArgs (Score.unwrap S s)
     pruneStrategy := .usePrimary }
 
 instance : Inhabited ScorerBundle where
@@ -279,7 +350,6 @@ instance : Inhabited ScorerBundle where
     penaltyScore := default
     worstScore := default
     scoreBadness := fun _ => 0.0
-    ctorWeightArgs := fun _ => #[1, 0, 0, 0]
     pruneStrategy := .noPruning
   }
 
@@ -703,7 +773,6 @@ instance : Scorable GradedUniformDensityScore where
         | .Unlikely => 0.66 | .Desperate => 1.0
       let severity := max speedVal likelVal * 0.7 + min speedVal likelVal * 0.3
       min 1.0 (0.75 + severity * 0.25 + varDepPenalty)
-  weightArgs s := #[s.density.toNat, s.checkSpeed.toNat, s.passLikelihood.toNat, s.varDeps]
 
 private def estimateTypeCtorCount (indName : Name) : MetaM (Option Nat) := do
   let env ← getEnv
@@ -1035,7 +1104,6 @@ instance : Scorable InputAwareGradedScore where
         | .Unlikely => 0.66 | .Desperate => 1.0
       let severity := max speedVal likelVal * 0.7 + min speedVal likelVal * 0.3
       min 1.0 (0.75 + severity * 0.25 + varDepPenalty + inputPenalty)
-  weightArgs s := #[s.density.toNat, s.checkSpeed.toNat, s.passLikelihood.toNat, s.varDeps]
 
 private def countInputCheckDeps (inputVars : Std.HashSet Name) (src : Source) : Nat :=
   let allVars := match src with

--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -59,8 +59,9 @@ def defaultCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (numBa
     else max 1 (numBase * size / max 1 numRec)
   else 1
 
-/-- QuickChick-style weight: base=1, recursive=size+1. Ignores score. -/
-def quickchickCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
+/-- Size-proportional weight: base=1, recursive=size+1. Ignores score.
+    (This is the strategy used by QuickChick.) -/
+def sizeProportionalCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
   if isRec then size + 1 else 1
 
 /-- Flat weight: every constructor gets weight 1. Ignores everything. -/
@@ -111,7 +112,7 @@ def registerWeightFn (name : Name) (fn : CtorWeightFn) (leanName : Name) : IO Un
   weightFnRegistry.modify (·.push { name, fn, leanName })
 
 initialize registerWeightFn `Scoring.defaultCtorWeight defaultCtorWeight ``defaultCtorWeight
-initialize registerWeightFn `Scoring.quickchickCtorWeight quickchickCtorWeight ``quickchickCtorWeight
+initialize registerWeightFn `Scoring.sizeProportionalCtorWeight sizeProportionalCtorWeight ``sizeProportionalCtorWeight
 initialize registerWeightFn `Scoring.flatCtorWeight flatCtorWeight ``flatCtorWeight
 initialize registerWeightFn `Scoring.scoreAwareCtorWeight scoreAwareCtorWeight ``scoreAwareCtorWeight
 initialize registerWeightFn `Scoring.balancedCtorWeight balancedCtorWeight ``balancedCtorWeight
@@ -149,7 +150,25 @@ def getActiveWeightFn : CoreM WeightFnEntry := do
     - `bestOf`: pick the best from a list (for leaf: best covering ctor)
     - `uncoveredPenalty`: score assigned to a leaf with no covering constructor
     - `worst`: initial upper bound for branch-and-bound (must lose to any real score)
-    - `badness`: map to [0,1] for HSL color (0 = green/good, 1 = red/bad) -/
+    - `badness`: map to [0,1] for HSL color (0 = green/good, 1 = red/bad)
+
+    **Required invariants for correct branch-and-bound pruning:**
+
+    1. **Monotonicity of `combine`**: for all `a b`, `¬ isBetter (combine a b) a`.
+       Extending a partial schedule with more steps can never improve its score.
+       This ensures pruning an intermediate node (whose children can only be worse)
+       never discards the true optimum.
+    2. **Transitivity of `isBetter`**: if `isBetter a b` and `isBetter b c` then
+       `isBetter a c`. Required for the bound to propagate correctly.
+    3. **`worst` is a valid initial bound**: for all reachable `s`, `¬ isBetter worst s`.
+       No real schedule should be pruned by the initial bound.
+    4. **`empty` is identity**: `combine empty s = s` and `combine s empty = s`.
+    5. **`badness` is monotone with `isBetter`**: if `isBetter a b` then
+       `badness a ≤ badness b`. Ensures weight functions don't reward worse schedules.
+
+    Invariant (1) is the critical soundness condition. Violations cause the search to
+    prune subtrees that contain better-scoring leaves, silently dropping valid schedules.
+    The current instances have not been formally verified against these invariants. -/
 class Scorable (S : Type) where
   empty : S
   combine : S → S → S
@@ -1162,6 +1181,164 @@ def inputAwareInductiveAggregator : InductiveAggregator InputAwareGradedScore :=
 
 initialize registerScoringBundle (mkScorerBundle `Scoring.InputAwareGradedScore
   inputAwareStepScorer inputAwareScheduleScorer inputAwareLeafAggregator inputAwareInductiveAggregator)
+
+----------------------------------------------
+-- Built-in: SourceQualityScore
+-- Tracks per-variable source quality across steps.
+-- Variables produced by SuchThat carry the dep's density as quality;
+-- variables produced by Unconstrained (InstVars) carry maximum penalty.
+-- A Check's penalty is the sum of its non-input args' source penalties,
+-- scaled by the relation's arity.
+----------------------------------------------
+
+inductive VarQuality
+  | Input       -- fixed input variable
+  | Purposeful  -- produced by SuchThat with a Total/Partial dep
+  | Constrained -- produced by SuchThat with a Backtracking/Checking dep
+  | Arbitrary   -- produced by Unconstrained (InstVars)
+  deriving Repr, BEq, Inhabited
+
+namespace VarQuality
+def toNat : VarQuality → Nat
+  | .Input => 0
+  | .Purposeful => 1
+  | .Constrained => 2
+  | .Arbitrary => 3
+
+def penalty : VarQuality → Nat
+  | .Input => 0
+  | .Purposeful => 0
+  | .Constrained => 1
+  | .Arbitrary => 3
+end VarQuality
+
+structure SourceQualityScore where
+  density        : Density := .Total
+  checkPenalty   : Nat := 0
+  checkSpeed     : CheckSpeed := .NotACheck
+  varDeps        : Nat := 0
+  deriving Repr, BEq, Inhabited
+
+deriving instance TypeName for SourceQualityScore
+
+instance : Ord SourceQualityScore where
+  compare a b :=
+    match compare a.density.toNat b.density.toNat with
+    | .eq => match compare a.checkPenalty b.checkPenalty with
+      | .eq => match compare a.checkSpeed.toNat b.checkSpeed.toNat with
+        | .eq => compare a.varDeps b.varDeps
+        | r => r
+      | r => r
+    | r => r
+
+instance : LT SourceQualityScore := ltOfOrd
+
+instance : Scorable SourceQualityScore where
+  empty := {}
+  combine a b :=
+    { density := Density.max a.density b.density
+      checkPenalty := a.checkPenalty + b.checkPenalty
+      checkSpeed := CheckSpeed.max a.checkSpeed b.checkSpeed
+      varDeps := a.varDeps + b.varDeps }
+  isBetter a b := a < b
+  bestOf scores := scores.foldl (fun acc s => if s < acc then s else acc) (scores.headD {})
+  uncoveredPenalty := { density := .Checking, checkPenalty := 100, checkSpeed := .Recursive, varDeps := 1000 }
+  worst := { density := .Checking, checkPenalty := 100, checkSpeed := .Recursive, varDeps := 1000 }
+  badness s :=
+    let d := s.density.toNat.toFloat / 3.0
+    let cp := min 1.0 (s.checkPenalty.toFloat / 20.0)
+    let c := s.checkSpeed.toNat.toFloat / 4.0
+    (d * 0.3 + cp * 0.4 + c * 0.2 + min 0.1 (s.varDeps.toFloat * 0.01))
+
+def sourceQualityWholeScheduleScorer : ResolvedWholeScheduleScorer := fun key memo inputVars steps => do
+  let mut varQualities : Std.HashMap Name VarQuality := {}
+  for v in inputVars do
+    varQualities := varQualities.insert v .Input
+  let mut score : SourceQualityScore := {}
+  for step in steps do
+    match step with
+    | .Unconstrained name _src _prodSort =>
+      varQualities := varQualities.insert name .Arbitrary
+      score := { score with density := Density.max score.density .Total }
+    | .SuchThat outputs src prodSort =>
+      let depDensity := match src with
+        | .Rec .. | .MutRec .. => Density.Partial
+        | .NonRec (indName, args) =>
+          let outputIdxs := outputs.filterMap fun (n, _) =>
+            args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+          let depDeriveSort := match prodSort with
+            | .Enumerator => DeriveSort.Enumerator
+            | .Generator => DeriveSort.Generator
+          let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+          if depKey == key then Density.Partial
+          else match memo[depKey]? with
+            | some (.done depSched) => (Score.unwrap SourceQualityScore depSched.score).density
+            | _ => Density.Partial
+      let quality := match depDensity with
+        | .Total | .Partial => VarQuality.Purposeful
+        | .Backtracking | .Checking => VarQuality.Constrained
+      for (name, _) in outputs do
+        varQualities := varQualities.insert name quality
+      score := { score with density := Density.max score.density depDensity }
+    | .Check src _polarity =>
+      let args := sourceArgs src
+      let allVars := args.flatMap varsInConstructorExpr
+      let arity := args.length
+      let mut penalty : Nat := 0
+      for v in allVars do
+        let q := varQualities[v]?.getD .Arbitrary
+        penalty := penalty + q.penalty
+      let scaledPenalty := penalty * arity
+      let varDeps := allVars.filter (!inputVars.contains ·) |>.length
+      let speed := classifyCheckSpeed memo key src varDeps
+      score := { score with
+        density := .Checking
+        checkPenalty := score.checkPenalty + scaledPenalty
+        checkSpeed := CheckSpeed.max score.checkSpeed speed
+        varDeps := score.varDeps + varDeps }
+    | .Match .. =>
+      score := { score with density := Density.max score.density .Backtracking }
+  return Score.wrap score
+
+def sourceQualityStepScorer : StepScorer SourceQualityScore := fun key memo inputVars step => do
+  match step with
+  | .Unconstrained .. => return { density := .Total }
+  | .Match .. => return { density := .Backtracking }
+  | .Check src _polarity =>
+    let varDeps := countGeneratedVarDeps inputVars src
+    let speed := classifyCheckSpeed memo key src varDeps
+    return { density := .Checking, checkSpeed := speed, varDeps := varDeps, checkPenalty := varDeps * (sourceArgs src).length }
+  | .SuchThat _outputs src prodSort =>
+    let depDensity := match src with
+      | .Rec .. | .MutRec .. => Density.Partial
+      | .NonRec (indName, args) =>
+        let outputIdxs := _outputs.filterMap fun (n, _) =>
+          args.findIdx? fun a => match a with | .Unknown v => v == n | _ => false
+        let depDeriveSort := match prodSort with
+          | .Enumerator => DeriveSort.Enumerator
+          | .Generator => DeriveSort.Generator
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIdxs, deriveSort := depDeriveSort }
+        if depKey == key then Density.Partial
+        else match memo[depKey]? with
+          | some (.done depSched) => (Score.unwrap SourceQualityScore depSched.score).density
+          | _ => Density.Partial
+    return { density := depDensity }
+
+def sourceQualityScheduleScorer : ScheduleScorer SourceQualityScore := fun stepScores =>
+  stepScores.foldl Scorable.combine Scorable.empty
+
+def sourceQualityLeafAggregator : LeafAggregator SourceQualityScore := fun ctors =>
+  match ctors with
+  | [] => Scorable.uncoveredPenalty
+  | _ => Scorable.bestOf (ctors.map Prod.snd)
+
+def sourceQualityInductiveAggregator : InductiveAggregator SourceQualityScore := fun leafScores =>
+  leafScores.foldl Scorable.combine Scorable.empty
+
+initialize do
+  let base := mkScorerBundle `Scoring.SourceQualityScore
+    sourceQualityStepScorer sourceQualityScheduleScorer sourceQualityLeafAggregator sourceQualityInductiveAggregator
+  registerScoringBundle { base with wholeScheduleScorer := some sourceQualityWholeScheduleScorer }
 
 
 end Scoring

--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -45,15 +45,32 @@ open Lean Meta Schedules
 ----------------------------------------------
 
 /-- A weight function computes the runtime frequency weight for a constructor.
-    Arguments: (scoreBadness, isRec, size, numBase, numRec).
-    - scoreBadness: per-constructor quality from the active scorer (0.0 = best, 1.0 = worst)
-    - isRec: whether this constructor is recursive
-    - size: current generation size parameter
-    - numBase/numRec: counts of base vs recursive constructors for this inductive -/
-abbrev CtorWeightFn := Float → Bool → Nat → Nat → Nat → Nat
+    The backtracking combinator picks constructors proportionally to their weights.
+
+    Arguments: (ctorName, outputIndices, deriveSort, scoreBadness, isRec, size, numBase, numRec).
+    - ctorName: the fully qualified name of the constructor (e.g. `List.cons)
+    - outputIndices: the output position indices for this derivation
+    - deriveSort: whether we are deriving a Generator, Enumerator, Checker, or Theorem
+    - scoreBadness: per-constructor quality from the active scorer (0.0 = best, 1.0 = worst).
+      Computed at elaboration time from the schedule search and baked in as a literal.
+    - isRec: whether this constructor is recursive (has a hypothesis referring back to
+      the inductive being derived)
+    - size: current generation size parameter (decreases as the generator recurses deeper;
+      at size=0, most functions return weight 0 or 1 for recursive ctors to force base cases)
+    - numBase/numRec: counts of base vs recursive constructors for this inductive
+
+    Returns: a Nat weight. Higher weight = chosen more often.
+
+    **Customization:** Users can define and register their own weight function targeting
+    specific constructors in their own file without modifying Specimen. Use the ctorName,
+    outputIndices, and deriveSort arguments to override weights for particular constructors
+    or modes while falling back to a default for others. See README.md for an example. Use
+    `set_option specimen.weightFn "yourFnName" in` to scope it to a specific derivation. -/
+abbrev CtorWeightFn := Name → List Nat → DeriveSort → Float → Bool → Nat → Nat → Nat → Nat
 
 /-- Ignores score; base=1, recursive=numBase*size/numRec. -/
-def defaultCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+def defaultCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (_scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
   if isRec then
     if size == 0 then 1
     else max 1 (numBase * size / max 1 numRec)
@@ -61,16 +78,19 @@ def defaultCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (numBa
 
 /-- Size-proportional weight: base=1, recursive=size+1. Ignores score.
     (This is the strategy used by QuickChick.) -/
-def sizeProportionalCtorWeight (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
+def sizeProportionalCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
   if isRec then size + 1 else 1
 
 /-- Flat weight: every constructor gets weight 1. Ignores everything. -/
-def flatCtorWeight (_scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat := 1
+def flatCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (_scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat := 1
 
 /-- Score-aware weight: boosts good constructors (low badness) and deprioritizes
     recursive ones. Quality maps to 1–4, recursive ctors get an additional size-based
     penalty so base cases are preferred at small sizes. -/
-def scoreAwareCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
+def scoreAwareCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (scoreBadness : Float) (isRec : Bool) (size : Nat) (numBase numRec : Nat) : Nat :=
   let quality := if scoreBadness < 0.25 then 4
     else if scoreBadness < 0.5 then 3
     else if scoreBadness < 0.75 then 2
@@ -84,7 +104,8 @@ def scoreAwareCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (num
     Controls aggregate P(recursive) ≈ size / (size + 4*numBase) by distributing
     size across all recursive ctors (so total rec weight ≈ size * quality).
     Base ctors get a 4x boost so they stay relevant even with many rec branches. -/
-def balancedCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase numRec : Nat) : Nat :=
+def balancedCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase numRec : Nat) : Nat :=
   let quality := if scoreBadness < 0.25 then 4
     else if scoreBadness < 0.5 then 3
     else if scoreBadness < 0.75 then 2
@@ -95,7 +116,8 @@ def balancedCtorWeight (scoreBadness : Float) (isRec : Bool) (size : Nat) (_numB
   else quality * 4
 
 /-- Quality-only weight: no structural bias, budget splitting handles termination. -/
-def qualityCtorWeight (scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat :=
+def qualityCtorWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (scoreBadness : Float) (_isRec : Bool) (_size : Nat) (_numBase _numRec : Nat) : Nat :=
   if scoreBadness < 0.25 then 4
   else if scoreBadness < 0.5 then 3
   else if scoreBadness < 0.75 then 2
@@ -108,6 +130,8 @@ structure WeightFnEntry where
 
 initialize weightFnRegistry : IO.Ref (Array WeightFnEntry) ← IO.mkRef #[]
 
+/-- Register a weight function so it can be selected via `set_option specimen.weightFn`.
+    Call this in an `initialize` block in your own file to add custom weight functions. -/
 def registerWeightFn (name : Name) (fn : CtorWeightFn) (leanName : Name) : IO Unit :=
   weightFnRegistry.modify (·.push { name, fn, leanName })
 
@@ -118,9 +142,82 @@ initialize registerWeightFn `Scoring.scoreAwareCtorWeight scoreAwareCtorWeight `
 initialize registerWeightFn `Scoring.balancedCtorWeight balancedCtorWeight ``balancedCtorWeight
 initialize registerWeightFn `Scoring.qualityCtorWeight qualityCtorWeight ``qualityCtorWeight
 
+----------------------------------------------
+-- Weight modifier (transforms the base weight)
+----------------------------------------------
+
+/-- A weight modifier transforms the weight computed by the active weight function.
+    The first argument is the base weight (already computed by the active `CtorWeightFn`).
+    The remaining arguments provide context for targeted overrides.
+
+    Return the final weight. To pass through unchanged, just return `baseWeight`.
+    To override for specific constructors, match on `ctorName`. To scale, multiply
+    `baseWeight`. -/
+abbrev CtorWeightModifier := Nat → Name → List Nat → DeriveSort → Float → Bool → Nat → Nat → Nat → Nat
+
+/-- Identity modifier: returns the base weight unchanged. -/
+def idWeightModifier (baseWeight : Nat) (_ctorName : Name) (_outputIndices : List Nat)
+    (_deriveSort : DeriveSort) (_scoreBadness : Float) (_isRec : Bool) (_size : Nat)
+    (_numBase _numRec : Nat) : Nat :=
+  baseWeight
+
+structure WeightModifierEntry where
+  name : Name
+  fn : CtorWeightModifier
+  leanName : Name
+
+initialize weightModifierRegistry : IO.Ref (Array WeightModifierEntry) ← IO.mkRef #[]
+
+/-- Register a weight modifier so it can be selected via `set_option specimen.weightModifier`.
+    Call this in an `initialize` block in your own file. -/
+def registerWeightModifier (name : Name) (fn : CtorWeightModifier) (leanName : Name) : IO Unit :=
+  weightModifierRegistry.modify (·.push { name, fn, leanName })
+
+register_option specimen.weightModifier : String := {
+  defValue := ""
+  descr := "Optional weight modifier applied after the weight function. " ++
+    "Receives the computed base weight as first argument. Empty string means no modifier."
+}
+
+/-- Get the active weight modifier name from options (empty = none). -/
+def getActiveWeightModifierName [Monad m] [MonadOptions m] : m (Option Name) := do
+  let s : String := Lean.Option.get (← getOptions) specimen.weightModifier
+  if s.isEmpty then return none
+  else return some s.toName
+
+private unsafe def resolveWeightModifierImpl (env : Environment) (opts : Options) (name : Name) : CtorWeightModifier :=
+  match env.evalConst CtorWeightModifier opts name with
+  | .ok fn => fn
+  | .error _ => idWeightModifier
+
+@[implemented_by resolveWeightModifierImpl]
+private opaque resolveWeightModifier (env : Environment) (opts : Options) (name : Name) : CtorWeightModifier
+
+/-- Resolve the active weight modifier entry, if any.
+    Like `getActiveWeightFn`, falls back to environment lookup for same-file definitions. -/
+def getActiveWeightModifier : CoreM (Option WeightModifierEntry) := do
+  match ← getActiveWeightModifierName with
+  | none => return none
+  | some name =>
+    let entries ← weightModifierRegistry.get
+    match entries.find? (·.name == name) with
+    | some entry => return some entry
+    | none =>
+      let env ← getEnv
+      if env.contains name then
+        let opts ← getOptions
+        let fn := resolveWeightModifier env opts name
+        return some { name := name, fn := fn, leanName := name }
+      else return none
+
+----------------------------------------------
+-- Weight function option and resolution
+----------------------------------------------
+
 register_option specimen.weightFn : String := {
   defValue := "Scoring.balancedCtorWeight"
-  descr := "The weight function used for constructor frequency in derived generators."
+  descr := "The weight function used for constructor frequency in derived generators. " ++
+    "Use `set_option specimen.weightFn \"yourFnName\" in` to scope to a specific derivation."
 }
 
 /-- Get the active weight function name from options. -/
@@ -128,15 +225,31 @@ def getActiveWeightFnName [Monad m] [MonadOptions m] : m Name := do
   let s : String := Lean.Option.get (← getOptions) specimen.weightFn
   return s.toName
 
-/-- Resolve the active weight function entry. -/
+private unsafe def resolveWeightFnImpl (env : Environment) (opts : Options) (name : Name) : CtorWeightFn :=
+  match env.evalConst CtorWeightFn opts name with
+  | .ok fn => fn
+  | .error _ => balancedCtorWeight
+
+@[implemented_by resolveWeightFnImpl]
+private opaque resolveWeightFn (env : Environment) (opts : Options) (name : Name) : CtorWeightFn
+
+/-- Resolve the active weight function entry.
+    First checks the registry (for built-in functions registered via `initialize`),
+    then falls back to resolving the function from the environment directly (for
+    user-defined functions in the same file that haven't been registered yet). -/
 def getActiveWeightFn : CoreM WeightFnEntry := do
   let name ← getActiveWeightFnName
   let entries ← weightFnRegistry.get
   match entries.find? (·.name == name) with
   | some entry => return entry
-  | none => match entries[0]? with
-    | some entry => return entry
-    | none => return { name := `Scoring.balancedCtorWeight, fn := balancedCtorWeight, leanName := ``balancedCtorWeight }
+  | none =>
+    let env ← getEnv
+    if env.contains name then
+      let opts ← getOptions
+      let fn := resolveWeightFn env opts name
+      return { name := name, fn := fn, leanName := name }
+    else
+      return { name := `Scoring.balancedCtorWeight, fn := balancedCtorWeight, leanName := ``balancedCtorWeight }
 
 ----------------------------------------------
 -- Core typeclass

--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -202,6 +202,9 @@ abbrev ResolvedLeafAggregator := List (Name × Score) → Score
 /-- A resolved inductive aggregator. -/
 abbrev ResolvedInductiveAggregator := List Score → Score
 
+/-- A resolved whole-schedule scorer that scores an entire schedule at once (for state-tracking scorers). -/
+abbrev ResolvedWholeScheduleScorer := SpecKey → Std.HashMap SpecKey MemoEntry → Std.HashSet Name → List ScheduleStep → MetaM Score
+
 ----------------------------------------------
 -- Default score type
 ----------------------------------------------
@@ -314,6 +317,10 @@ structure ScorerBundle where
   /-- Map score to [0,1] for HSL color display (0 = best, 1 = worst). -/
   scoreBadness : Score → Float
   pruneStrategy : PruneStrategy := .usePrimary
+  /-- Optional whole-schedule scorer. When present, `searchBestScheduleM` uses
+      this instead of `stepScorer` + `scheduleScorer`. Allows tracking state across
+      steps (e.g., variable source quality). -/
+  wholeScheduleScorer : Option ResolvedWholeScheduleScorer := none
 
 /-- Build a complete ScorerBundle from typed scorers. -/
 def mkScorerBundle [Inhabited S] [TypeName S] [Repr S] [Scorable S]

--- a/Specimen/SearchTree.lean
+++ b/Specimen/SearchTree.lean
@@ -72,6 +72,7 @@ def enumDependencySatisfyingOrderingsTree {α v} [BEq α] [Repr α] [Repr v] [BE
 
 
 
+
 -- Prune tree with global best score state
 partial def pruneTreeWithScore {α σ} [LT σ] [Min σ] [DecidableRel (fun a b : σ => a < b)] (tree : LazyRoseTree α) (score : α → σ) (bestScore : σ) : Option (LazyRoseTree α × σ) :=
 

--- a/SpecimenTest.lean
+++ b/SpecimenTest.lean
@@ -105,4 +105,7 @@ import SpecimenTest.ArithCompiler.FancyCompilerBuggyTest
 -- Schedule quality regression tests
 import SpecimenTest.ScheduleQualityRegressionTest
 
+-- Weight function / modifier customization tests
+import SpecimenTest.WeightCustomizationTest
+
 

--- a/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
+++ b/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
@@ -86,6 +86,7 @@ instance {α : Type} {a : α} [Repr α] [ArbitraryFueled α] [DecidableEq α] : 
 
 deriving instance DecidableEq for PathSet
 
+#guard_msgs(drop info) in
 set_option specimen.scoreType "Scoring.SourceQualityScore" in
 set_option specimen.autoDeriveDeps true in
 set_option specimen.multiOutput true in

--- a/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
+++ b/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
@@ -86,7 +86,7 @@ instance {α : Type} {a : α} [Repr α] [ArbitraryFueled α] [DecidableEq α] : 
 
 deriving instance DecidableEq for PathSet
 
-set_option specimen.scoreType "Scoring.DensityScore" in
+set_option specimen.scoreType "Scoring.SourceQualityScore" in
 set_option specimen.autoDeriveDeps true in
 set_option specimen.multiOutput true in
 #time derive_mutual

--- a/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
+++ b/SpecimenTest/CedarExample/CedarCheckerGenerators.lean
@@ -86,7 +86,7 @@ instance {α : Type} {a : α} [Repr α] [ArbitraryFueled α] [DecidableEq α] : 
 
 deriving instance DecidableEq for PathSet
 
-
+set_option specimen.scoreType "Scoring.DensityScore" in
 set_option specimen.autoDeriveDeps true in
 set_option specimen.multiOutput true in
 #time derive_mutual

--- a/SpecimenTest/CedarExample/CedarWellTypedTermGenerator.lean
+++ b/SpecimenTest/CedarExample/CedarWellTypedTermGenerator.lean
@@ -175,5 +175,5 @@ def genWellFormedTypeAndExpr (fuel : Nat) : Gen (CedarType × CedarExpr) := do
 #guard_msgs(drop info) in
 #eval Gen.printSamples (genSchemaThenCedarExpr 3)
 
-#guard_msgs(drop info) in
+-- #guard_msgs(drop info) in
 #eval Gen.printSamples (genWellFormedTypeAndExpr 3)

--- a/SpecimenTest/CedarExample/CedarWellTypedTermGenerator.lean
+++ b/SpecimenTest/CedarExample/CedarWellTypedTermGenerator.lean
@@ -175,5 +175,5 @@ def genWellFormedTypeAndExpr (fuel : Nat) : Gen (CedarType × CedarExpr) := do
 #guard_msgs(drop info) in
 #eval Gen.printSamples (genSchemaThenCedarExpr 3)
 
--- #guard_msgs(drop info) in
-#eval Gen.printSamples (genWellFormedTypeAndExpr 3)
+#guard_msgs(drop info) in
+#eval Gen.printSamples (genWellFormedTypeAndExpr 5)

--- a/SpecimenTest/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DerivePermutationGenerator.lean
@@ -7,6 +7,7 @@ import SpecimenTest.CommonDefinitions.Permutation
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual
   (∃ l l', Permutation l' l)
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveRegExpMatchGenerator.lean
@@ -64,6 +64,7 @@ def r0 : RegExp :=
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual
   (fun re => ∃ (s : List Nat), ExpMatch s re)
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveSTLCGenerator.lean
@@ -16,6 +16,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual
   (fun G t => ∃ (e : term), typing G e t)
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/MultiOutputTest.lean
@@ -26,7 +26,5 @@ derive_generator (fun n => ∃ a b, Split n a b)
 #guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat (Nat × Nat) (fun (a, b) => Split 5 a b))
 
-set_option trace.plausible.deriving.results true
-
 #guard_msgs(drop info) in
 derive_generator (∃ a n b, Split n a b)

--- a/SpecimenTest/DeriveArbitrarySuchThat/UserInstancePriorityTest.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/UserInstancePriorityTest.lean
@@ -28,6 +28,7 @@ structure NatPair where
 inductive HasSum10 : NatPair → Prop where
   | mk : Sums x y 10 → HasSum10 ⟨x, y⟩
 
+#guard_msgs(drop info) in
 set_option specimen.autoDeriveDeps true in
 set_option specimen.multiOutput true in
 derive_mutual (∃ (self : _), HasSum10 self)

--- a/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
@@ -14,6 +14,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual checker
   (fun lo hi t => BST lo hi t)
 

--- a/SpecimenTest/DeriveDecOpt/DeriveBalancedTreeChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveBalancedTreeChecker.lean
@@ -12,6 +12,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual checker
   (fun n t => balancedTree n t)
 

--- a/SpecimenTest/DeriveDecOpt/DerivePermutationChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DerivePermutationChecker.lean
@@ -8,6 +8,7 @@ import SpecimenTest.DeriveEnumSuchThat.DerivePermutationEnumerator
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual checker
   (fun l l' => Permutation l l')
 

--- a/SpecimenTest/DeriveDecOpt/DeriveRegExpMatchChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveRegExpMatchChecker.lean
@@ -21,6 +21,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual checker
   (fun s r0 => ExpMatch s r0)
 

--- a/SpecimenTest/DeriveDecOpt/DeriveSTLCChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveSTLCChecker.lean
@@ -14,6 +14,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual checker
   (fun Γ e τ => typing Γ e τ)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
@@ -11,6 +11,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual enumerator
   (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveBalancedTreeEnumerator.lean
@@ -12,6 +12,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual enumerator
   (fun n => ∃ (t : BinaryTree), balancedTree n t)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -7,6 +7,7 @@ import SpecimenTest.CommonDefinitions.Permutation
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual enumerator
   (∃ l l', Permutation l' l)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveRegExpMatchEnumerator.lean
@@ -12,6 +12,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual enumerator
   (fun r0 => ∃ (s : List Nat), ExpMatch s r0)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveSTLCEnumerator.lean
@@ -12,6 +12,7 @@ import SpecimenTest.DeriveEnum.DeriveSTLCTermTypeEnumerators
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
+#guard_msgs(drop info) in
 derive_mutual enumerator
   (fun Γ τ => ∃ (e : term), typing Γ e τ)
 

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -74,7 +74,7 @@ section GeneratorQuality
 
 private def treeDepth : BinaryTree → Nat
   | .Leaf => 0
-  | .Node _ l r => 1 + max (treeDepth l) (treeDepth r)
+  | .Node _ l r => 1 + (treeDepth l) + (treeDepth r)
 
 structure QualityStats where
   trials : Nat
@@ -180,6 +180,12 @@ inductive BST_InputAware : Nat → Nat → BinaryTree → Prop
       Between lo x hi → BST_InputAware lo x l → BST_InputAware x hi r →
       BST_InputAware lo hi (.Node x l r)
 
+inductive BST_SourceQuality : Nat → Nat → BinaryTree → Prop
+  | bstLeaf : BST_SourceQuality lo hi .Leaf
+  | bstNode : ∀ x l r lo hi,
+      Between lo x hi → BST_SourceQuality lo x l → BST_SourceQuality x hi r →
+      BST_SourceQuality lo hi (.Node x l r)
+
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
@@ -207,11 +213,15 @@ set_option specimen.scoreType "Scoring.InputAwareGradedScore" in
 #guard_msgs(drop info) in
 derive_mutual (fun lo hi => ∃ t, BST_InputAware lo hi t)
 
+set_option specimen.scoreType "Scoring.SourceQualityScore" in
+#guard_msgs(drop info) in
+derive_mutual (fun lo hi => ∃ t, BST_SourceQuality lo hi t)
+
 #guard_msgs(drop info) in
 #eval do
   let sample (gen : Nat → Gen BinaryTree) (name : String) : IO Unit := do
     let stats ← sampleQuality gen treeDepth
-      (fun a b => toString (repr a) == toString (repr b)) 200 8
+      (fun a b => toString (repr a) == toString (repr b)) 200 100
     IO.println (ppStats name stats)
     assertQuality name stats (minSuccessRate := 0.5) (minUniques := 10)
 
@@ -228,5 +238,7 @@ derive_mutual (fun lo hi => ∃ t, BST_InputAware lo hi t)
   sample instB.arbitrarySizedST "  BoundedScore  "
   let instIA : ArbitrarySizedSuchThat BinaryTree (fun t => BST_InputAware 0 10 t) := inferInstance
   sample instIA.arbitrarySizedST "  InputAware    "
+  let instIB : ArbitrarySizedSuchThat BinaryTree (fun t => BST_SourceQuality 0 10 t) := inferInstance
+  sample instIB.arbitrarySizedST "  SourceQuality    "
 
 end StrategyComparison

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -30,9 +30,13 @@ set_option match.ignoreUnusedAlts true
 
 -- Sections 1-4 previously snapshotted the aux_arb internal functions.
 -- With derive_mutual, instances use global defs instead. Verify instances exist:
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat Nat (fun x => Between 0 x 10))
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat BinaryTree (fun t => BST 0 10 t))
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat term (fun e => typing [] e .Nat))
+#guard_msgs(drop info) in
 #check (inferInstance : ArbitrarySizedSuchThat (List Nat) (fun s => ExpMatch s (.Char 1)))
 
 -- ============================================================
@@ -72,9 +76,9 @@ fun fuel initSize size n_1 =>
 
 section GeneratorQuality
 
-private def treeDepth : BinaryTree → Nat
+private def treeNodeCount : BinaryTree → Nat
   | .Leaf => 0
-  | .Node _ l r => 1 + (treeDepth l) + (treeDepth r)
+  | .Node _ l r => 1 + (treeNodeCount l) + (treeNodeCount r)
 
 structure QualityStats where
   trials : Nat
@@ -220,7 +224,7 @@ derive_mutual (fun lo hi => ∃ t, BST_SourceQuality lo hi t)
 #guard_msgs(drop info) in
 #eval do
   let sample (gen : Nat → Gen BinaryTree) (name : String) : IO Unit := do
-    let stats ← sampleQuality gen treeDepth
+    let stats ← sampleQuality gen treeNodeCount
       (fun a b => toString (repr a) == toString (repr b)) 200 100
     IO.println (ppStats name stats)
     assertQuality name stats (minSuccessRate := 0.5) (minUniques := 10)
@@ -242,3 +246,8 @@ derive_mutual (fun lo hi => ∃ t, BST_SourceQuality lo hi t)
   sample instIB.arbitrarySizedST "  SourceQuality    "
 
 end StrategyComparison
+
+-- TODO: Strategy differentiation tests require module-local instances so that
+-- the same relation can be derived under multiple strategies and compared at
+-- runtime. Currently derive_mutual registers global instances, preventing A/B
+-- comparison in a single module. See GitHub issue for tracking.

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -162,6 +162,24 @@ inductive BST_Density : Nat → Nat → BinaryTree → Prop
       Between lo x hi → BST_Density lo x l → BST_Density x hi r →
       BST_Density lo hi (.Node x l r)
 
+inductive BST_Graded : Nat → Nat → BinaryTree → Prop
+  | bstLeaf : BST_Graded lo hi .Leaf
+  | bstNode : ∀ x l r lo hi,
+      Between lo x hi → BST_Graded lo x l → BST_Graded x hi r →
+      BST_Graded lo hi (.Node x l r)
+
+inductive BST_Bounded : Nat → Nat → BinaryTree → Prop
+  | bstLeaf : BST_Bounded lo hi .Leaf
+  | bstNode : ∀ x l r lo hi,
+      Between lo x hi → BST_Bounded lo x l → BST_Bounded x hi r →
+      BST_Bounded lo hi (.Node x l r)
+
+inductive BST_InputAware : Nat → Nat → BinaryTree → Prop
+  | bstLeaf : BST_InputAware lo hi .Leaf
+  | bstNode : ∀ x l r lo hi,
+      Between lo x hi → BST_InputAware lo x l → BST_InputAware x hi r →
+      BST_InputAware lo hi (.Node x l r)
+
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
@@ -176,6 +194,18 @@ derive_mutual (fun lo hi => ∃ t, BST_WorstLeaf lo hi t)
 set_option specimen.scoreType "Scoring.DensityScore" in
 #guard_msgs(drop info) in
 derive_mutual (fun lo hi => ∃ t, BST_Density lo hi t)
+
+set_option specimen.scoreType "Scoring.GradedUniformDensityScore" in
+#guard_msgs(drop info) in
+derive_mutual (fun lo hi => ∃ t, BST_Graded lo hi t)
+
+set_option specimen.scoreType "Scoring.BoundedGradedScore" in
+#guard_msgs(drop info) in
+derive_mutual (fun lo hi => ∃ t, BST_Bounded lo hi t)
+
+set_option specimen.scoreType "Scoring.InputAwareGradedScore" in
+#guard_msgs(drop info) in
+derive_mutual (fun lo hi => ∃ t, BST_InputAware lo hi t)
 
 #guard_msgs(drop info) in
 #eval do
@@ -192,5 +222,11 @@ derive_mutual (fun lo hi => ∃ t, BST_Density lo hi t)
   sample instW.arbitrarySizedST "  WorstLeafScore"
   let instDn : ArbitrarySizedSuchThat BinaryTree (fun t => BST_Density 0 10 t) := inferInstance
   sample instDn.arbitrarySizedST "  DensityScore  "
+  let instG : ArbitrarySizedSuchThat BinaryTree (fun t => BST_Graded 0 10 t) := inferInstance
+  sample instG.arbitrarySizedST "  GradedScore   "
+  let instB : ArbitrarySizedSuchThat BinaryTree (fun t => BST_Bounded 0 10 t) := inferInstance
+  sample instB.arbitrarySizedST "  BoundedScore  "
+  let instIA : ArbitrarySizedSuchThat BinaryTree (fun t => BST_InputAware 0 10 t) := inferInstance
+  sample instIA.arbitrarySizedST "  InputAware    "
 
 end StrategyComparison

--- a/SpecimenTest/ScheduleQualityRegressionTest.lean
+++ b/SpecimenTest/ScheduleQualityRegressionTest.lean
@@ -84,20 +84,20 @@ structure QualityStats where
   trials : Nat
   successes : Nat
   uniques : Nat
-  maxDepth : Nat
-  depthBuckets : Array Nat  -- [0-1, 2-3, 4-5, 6+]
+  maxSize : Nat
+  sizeBuckets : Array Nat  -- [0-1, 2-3, 4-5, 6+]
   elapsedMs : Nat := 0
   deriving Repr
 
 private def emptyStats (n : Nat) : QualityStats :=
-  { trials := n, successes := 0, uniques := 0, maxDepth := 0, depthBuckets := #[0, 0, 0, 0] }
+  { trials := n, successes := 0, uniques := 0, maxSize := 0, sizeBuckets := #[0, 0, 0, 0] }
 
-private def depthBucket (d : Nat) : Nat :=
+private def sizeBucket (d : Nat) : Nat :=
   if d ≤ 1 then 0 else if d ≤ 3 then 1 else if d ≤ 5 then 2 else 3
 
 /-- Sample a generator `trials` times, measuring success rate, unique count,
-    depth distribution, and wall-clock time. -/
-private def sampleQuality (gen : Nat → Gen α) (depth : α → Nat) (eq : α → α → Bool)
+    size distribution, and wall-clock time. -/
+private def sampleQuality (gen : Nat → Gen α) (measure : α → Nat) (eq : α → α → Bool)
     (trials : Nat := 200) (size : Nat := 3) : IO QualityStats := do
   let startNs ← IO.monoNanosNow
   let mut stats := emptyStats trials
@@ -106,10 +106,10 @@ private def sampleQuality (gen : Nat → Gen α) (depth : α → Nat) (eq : α �
     try
       let v ← Gen.run (gen size) (size + i % 4)
       stats := { stats with successes := stats.successes + 1 }
-      let d := depth v
-      stats := { stats with maxDepth := max stats.maxDepth d }
-      let bucket := depthBucket d
-      stats := { stats with depthBuckets := stats.depthBuckets.modify bucket (· + 1) }
+      let d := measure v
+      stats := { stats with maxSize := max stats.maxSize d }
+      let bucket := sizeBucket d
+      stats := { stats with sizeBuckets := stats.sizeBuckets.modify bucket (· + 1) }
       if !seen.any (eq v ·) then
         seen := seen.push v
     catch _ => pure ()
@@ -119,8 +119,8 @@ private def sampleQuality (gen : Nat → Gen α) (depth : α → Nat) (eq : α �
 
 private def ppStats (name : String) (s : QualityStats) : String :=
   let rate := (s.successes.toFloat / s.trials.toFloat * 100.0).round.toUInt32.toNat
-  let bucketStr := s!"{s.depthBuckets[0]!}/{s.depthBuckets[1]!}/{s.depthBuckets[2]!}/{s.depthBuckets[3]!}"
-  s!"{name}: {rate}% success, {s.uniques} uniques, maxDepth={s.maxDepth}, buckets=[{bucketStr}], {s.elapsedMs}ms"
+  let bucketStr := s!"{s.sizeBuckets[0]!}/{s.sizeBuckets[1]!}/{s.sizeBuckets[2]!}/{s.sizeBuckets[3]!}"
+  s!"{name}: {rate}% success, {s.uniques} uniques, maxSize={s.maxSize}, buckets=[{bucketStr}], {s.elapsedMs}ms"
 
 /-- Quality assertions: generators should meet minimum quality bars. -/
 private def assertQuality (name : String) (s : QualityStats)

--- a/SpecimenTest/WeightCustomizationTest.lean
+++ b/SpecimenTest/WeightCustomizationTest.lean
@@ -1,0 +1,132 @@
+import Specimen.DeriveConstrainedProducer
+import Plausible.Gen
+
+/-!
+# Weight Function and Modifier Distribution Tests
+
+Tests that changing the weight function or applying a modifier produces
+measurably different distributions. Uses Between (a Nat range relation)
+since the number of recursive steps directly determines the output value,
+making the weight's effect on distribution clearly measurable.
+-/
+
+open Plausible Scoring Schedules
+
+-- ============================================================
+-- Define 4 copies of Between to get separate instances
+-- ============================================================
+
+inductive BetweenA : Nat → Nat → Nat → Prop where
+  | here : ∀ lo hi, BetweenA lo hi lo
+  | there : ∀ lo hi n, BetweenA (lo + 1) hi n → BetweenA lo hi n
+
+inductive BetweenB : Nat → Nat → Nat → Prop where
+  | here : ∀ lo hi, BetweenB lo hi lo
+  | there : ∀ lo hi n, BetweenB (lo + 1) hi n → BetweenB lo hi n
+
+inductive BetweenC : Nat → Nat → Nat → Prop where
+  | here : ∀ lo hi, BetweenC lo hi lo
+  | there : ∀ lo hi n, BetweenC (lo + 1) hi n → BetweenC lo hi n
+
+inductive BetweenD : Nat → Nat → Nat → Prop where
+  | here : ∀ lo hi, BetweenD lo hi lo
+  | there : ∀ lo hi n, BetweenD (lo + 1) hi n → BetweenD lo hi n
+
+-- ============================================================
+-- Section 1: Balanced weights (default)
+-- ============================================================
+
+set_option specimen.weightFn "Scoring.balancedCtorWeight" in
+set_option specimen.autoDeriveDeps true in
+#guard_msgs(drop info) in
+derive_mutual
+  (fun (lo hi : Nat) => ∃ n, BetweenA lo hi n)
+
+-- ============================================================
+-- Section 2: Flat weights (recursive = base = 1)
+-- ============================================================
+
+set_option specimen.weightFn "Scoring.flatCtorWeight" in
+set_option specimen.autoDeriveDeps true in
+#guard_msgs(drop info) in
+derive_mutual
+  (fun (lo hi : Nat) => ∃ n, BetweenB lo hi n)
+
+-- ============================================================
+-- Section 3: Custom weight that heavily favors base case (here)
+-- ============================================================
+
+def heavyBaseWeight (_ctorName : Name) (_outputIndices : List Nat) (_deriveSort : DeriveSort)
+    (_scoreBadness : Float) (isRec : Bool) (size : Nat) (_numBase _numRec : Nat) : Nat :=
+  if isRec then (if size == 0 then 0 else 1) else 20
+
+initialize Scoring.registerWeightFn `heavyBaseWeight heavyBaseWeight ``heavyBaseWeight
+
+set_option specimen.weightFn "heavyBaseWeight" in
+set_option specimen.autoDeriveDeps true in
+#guard_msgs(drop info) in
+derive_mutual
+  (fun (lo hi : Nat) => ∃ n, BetweenC lo hi n)
+
+-- ============================================================
+-- Section 4: Modifier that triples recursive constructor weight
+-- ============================================================
+
+def tripleRecModifier (baseWeight : Nat) (_ctorName : Name) (_outputIndices : List Nat)
+    (_deriveSort : DeriveSort) (_scoreBadness : Float) (isRec : Bool) (_size : Nat)
+    (_numBase _numRec : Nat) : Nat :=
+  if isRec then baseWeight * 3 else baseWeight
+
+#eval Scoring.registerWeightModifier `tripleRecModifier tripleRecModifier ``tripleRecModifier
+
+set_option specimen.weightModifier "tripleRecModifier" in
+set_option specimen.autoDeriveDeps true in
+#guard_msgs(drop info) in
+derive_mutual
+  (fun (lo hi : Nat) => ∃ n, BetweenD lo hi n)
+
+-- ============================================================
+-- Section 5: Sample and check distribution relationships
+--
+-- Between lo hi n generates n in [lo, hi]. The generated value minus lo
+-- equals the number of `there` steps taken. So the average (n - lo)
+-- directly reflects how often the recursive constructor is chosen.
+-- ============================================================
+
+private def sampleAvgOffset (gen : Nat → Gen Nat) (lo : Nat)
+    (trials : Nat := 1000) (size : Nat := 8) : IO Float := do
+  let mut totalOffset : Nat := 0
+  let mut successes : Nat := 0
+  for i in [:trials] do
+    try
+      let n ← Gen.run (gen size) (size + i % 11)
+      totalOffset := totalOffset + (n - lo)
+      successes := successes + 1
+    catch _ => pure ()
+  if successes == 0 then return 0.0
+  return totalOffset.toFloat / successes.toFloat
+
+/-- info: PASS -/
+#guard_msgs in
+#eval do
+  let lo := 0
+  let avgBalanced ← sampleAvgOffset
+    (fun sz => ArbitrarySizedSuchThat.arbitrarySizedST (fun n => BetweenA lo 20 n) sz) lo
+  let avgFlat ← sampleAvgOffset
+    (fun sz => ArbitrarySizedSuchThat.arbitrarySizedST (fun n => BetweenB lo 20 n) sz) lo
+  let avgHeavyBase ← sampleAvgOffset
+    (fun sz => ArbitrarySizedSuchThat.arbitrarySizedST (fun n => BetweenC lo 20 n) sz) lo
+  let avgTripleRec ← sampleAvgOffset
+    (fun sz => ArbitrarySizedSuchThat.arbitrarySizedST (fun n => BetweenD lo 20 n) sz) lo
+
+  -- heavyBase should produce values closer to lo (fewer recursive steps)
+  unless avgHeavyBase < avgBalanced do
+    throw <| IO.userError s!"FAIL: Expected heavyBase ({avgHeavyBase}) < balanced ({avgBalanced})"
+  -- tripleRec modifier should produce values further from lo (more recursive steps)
+  unless avgTripleRec > avgBalanced do
+    throw <| IO.userError s!"FAIL: Expected tripleRec ({avgTripleRec}) > balanced ({avgBalanced})"
+  -- flat should produce values closer to lo than balanced (no size-boosting of rec)
+  unless avgFlat < avgBalanced do
+    throw <| IO.userError s!"FAIL: Expected flat ({avgFlat}) < balanced ({avgBalanced})"
+
+  IO.println "PASS"


### PR DESCRIPTION
## Summary
- Make `StepScorer` return `MetaM` so scorers can inspect dependency memo state at scoring time
- Emit `ctorWeight` calls in generated code so recursive constructor weights reflect schedule quality at runtime
- Add three new scorer bundles: `GradedUniformDensityScore`, `BoundedGradedScore`, `InputAwareGradedScore`
- Refine dominance pruning to only compare complete orderings (leaves), matching legacy semantics

## Test plan
- [x] All new scorers exercised in `ScheduleQualityRegressionTest` on BST [0,10]
- [x] Cedar example derives successfully with `DensityScore`
- [x] `lake env lean` passes on all modified files