### PR TITLE
Fix missing typeclass constraints for polymorphic dependencies

### DIFF
--- a/Docs/Constraint-propagation.md
+++ b/Docs/Constraint-propagation.md
@@ -1,69 +1,87 @@
 # Constraint Propagation for Polymorphic Dependencies
 
-## Problem
+## Overview
 
-When Specimen generates code for a polymorphic type like `GenList (α : Type) [Arbitrary α]`, the generated definition needs the right typeclass constraints on its type parameters. Previously, constraints were hardcoded per derive-sort: generators always got `[Arbitrary α]`, checkers always got `[Enum α, DecidableEq α]`. This caused two issues:
+When `derive_mutual` generates code for a spec involving polymorphic types, the generated definition needs typeclass constraints on its type parameters (e.g. `[Arbitrary α]`, `[DecidableEq α]`). Constraint propagation determines exactly which constraints each spec requires by walking the dependency graph bottom-up.
 
-1. **Unused constraints** — generators got `[Enum α]` they didn't need.
-2. **Missing constraints** — when a generator depends on a checker that shares a type parameter, the generator's hardcoded constraints didn't include `[Enum α]`, so the checker call inside the generated code couldn't find its required instance.
+## Architecture
 
-## Solution: Bottom-Up Propagation
+The system has four layers:
 
-Replace hardcoded constraints with a bottom-up walk through the dependency graph that discovers what each spec *actually needs*.
+1. **`extractTypeParamRefs`** — structural: which type params does a `ConstructorExpr` reference?
+2. **`synthExternalConstraints`** — semantic: for an external dep, what constraints does its instance need?
+3. **`computeSpecConstraints`** — per-spec: walk all schedule steps and collect constraints
+4. **`propagateConstraints`** — global: orchestrate across all components in topological order
 
-### Algorithm
+### Why bottom-up?
 
-After SCC decomposition gives us components in topological order (leaves first):
+Specs are organized into SCCs (strongly connected components) in topological order, leaves first. By the time we process a spec, all its non-mutual dependencies already have their constraints computed. This avoids re-derivation and gives us a single-pass algorithm for acyclic deps.
 
-```
-for each component (in topo order):
-  if singleton:
-    compute constraints by walking schedule steps
-  if mutual block:
-    fixed-point iteration until stable
-```
+### Why fixed-point for mutual blocks?
 
-For each schedule step, we determine constraints by its kind:
+In a mutual group, spec A may depend on spec B and vice versa. Neither can be computed first. We initialize all constraints to `∅` and iterate: recompute each spec's constraints using siblings' current sets, until no set changes. This converges because constraints can only grow (we never remove) and the universe of possible constraints is finite.
 
-| Step kind | Source of constraints |
-|-----------|---------------------|
-| `Unconstrained (NonRec)` on a bare type param | Own-sort class directly (`Arbitrary`/`Enum`) |
-| `Unconstrained (NonRec)` on a compound type | Synthesis: try `synth [TC (Foo α)]`, read back what the instance needs |
-| `Check (NonRec)` for Eq/Ne | `DecidableEq` (special case) |
-| `Check (NonRec)` for other relations | Look up internal dep map, else synthesize `DecOpt` |
-| `SuchThat (NonRec)` | Look up internal dep map, else synthesize `ArbitrarySizedSuchThat`/`EnumSizedSuchThat` |
-| `Rec` / self-recursive | No-op (constraints come from non-recursive steps) |
-| `MutRec` sibling | Look up sibling's current constraints (fixed-point) |
+## Per-Step Constraint Rules
 
-### Key design decisions
+`computeSpecConstraints` matches on each schedule step:
 
-**Why synthesis for external deps?** When a spec depends on something already in the environment (e.g. `Arbitrary (List α)`), we can't inspect its schedule—it doesn't have one. Instead we ask Lean's instance synthesis to find it, then read the instance's type signature to discover what constraints it required (e.g. `[Arbitrary α]`).
+### Unconstrained generation (`Unconstrained _ (NonRec (indName, args)) ps`)
 
-**Why fixed-point for mutual blocks?** In a mutual group, spec A might depend on spec B and vice versa. We iterate: compute A's constraints assuming B's current set, then B's assuming A's, repeat until neither changes.
+Three cases:
+- **Bare type param** (e.g. generating `α` directly): add the own-sort class (`Arbitrary` for generators, `Enum` for enumerators).
+- **Compound type referencing type params** (e.g. `List α`): use `synthExternalConstraints` to discover transitive requirements. Generating `List α` requires `Arbitrary (List α)`, whose instance in turn requires `[Arbitrary α]`.
+- **No type param involvement**: no constraint needed.
 
-**Why always add `DecidableEq`?** If a spec has *any* constraints, it almost certainly needs `DecidableEq` too (for equality checks in the generated code). Rather than track this precisely, we add it unconditionally when the constraint set is non-empty.
+### Checks (`Check (NonRec (indName, args)) _`)
 
-### Implementation
+- **Eq/Ne**: special-cased to `DecidableEq`. These are the only relations where we know the constraint statically — equality on a type param always needs decidable equality.
+- **Other relations**: three-tier lookup: internal dep map → sibling map (mutual) → synthesis of `DecOpt` on the relation (external). If synthesis fails entirely, conservatively fall back to `{Enum, DecidableEq}` — this only triggers for external deps where we can't determine the actual requirements.
 
-Core functions in `Specimen/DeriveConstrainedProducer.lean`:
+### SuchThat deps (`SuchThat _ (NonRec (indName, args)) ps`)
 
-- `extractTypeParamRefs` — walks a `ConstructorExpr` tree to find which type params it references
-- `synthExternalConstraints` — synthesizes an instance for a compound type and reads back the constraints from the instance's type signature
-- `computeSpecConstraints` — computes constraints for a single spec given the already-computed dep map
-- `propagateConstraints` — orchestrates the full bottom-up walk across all components
+Same three-tier lookup: internal map → sibling map → synthesis of `ArbitrarySizedSuchThat`/`EnumSizedSuchThat`.
 
-The computed constraints are passed to `compileInductiveSchedule` which emits them as instance binders in the generated definition.
+### Recursive and mutual-recursive steps
+
+- **Self-recursive** (`Rec`): no-op. Self-recursion doesn't introduce new constraints — whatever the spec needs is already captured by its non-recursive steps.
+- **Mutual-recursive** (`MutRec sibName`): look up the sibling's current constraint set from the fixed-point iteration map.
+
+### No blanket additions
+
+Constraints are collected strictly from what the schedule steps demand. If a generator only generates `List α` unconstrainedly, it gets `[Arbitrary α]` — it does NOT get `DecidableEq` unless some step actually needs it (e.g. an Eq check, or a checker dep that transitively requires it). This avoids polluting generated signatures with unnecessary constraints.
+
+## External Constraint Discovery (`synthExternalConstraints`)
+
+For deps not in the current `derive_mutual` call (already in the environment), we can't inspect their schedules. Instead:
+
+1. Build the fully-applied type expression (e.g. `List α`) with fresh metavariables for non-Sort params and local `Sort`-typed fvars with `[Enum], [Arbitrary], [DecidableEq]` instances available in context.
+2. Ask Lean to synthesize the target class (e.g. `Arbitrary (List α)`).
+3. On success, inspect the synthesized instance's **declaration type** — walk its forall binders and collect `instImplicit` domains. These are the constraints the instance needs (e.g. `[Arbitrary α]`).
+4. Also inspect the **goal type** itself for additional instance-implicit requirements.
+
+This two-pass inspection (declaration + goal) catches constraints from both the instance definition and from the typeclass itself.
+
+### Why provide all three classes in the synthesis context?
+
+When synthesizing `Arbitrary (List α)`, Lean needs `[Arbitrary α]` to be available in context. By providing `Enum`, `Arbitrary`, and `DecidableEq` instances on the fresh type fvars, we ensure synthesis succeeds for any instance that depends on standard classes. The constraints we *read back* from the synthesized instance tell us which subset is actually needed.
+
+### Edge cases
+
+- **Bare type param as indName** (e.g. step says "generate `α`"): short-circuit to returning the own-sort class directly without synthesis.
+- **Predicate-form classes** (`ArbitrarySizedSuchThat`, `EnumSizedSuchThat`): the instance type requires building a lambda predicate over output variables, not just a bare application.
+- **Synthesis failure**: return empty — the caller decides the fallback (checker defaults or nothing).
 
 ## Diagnostics
 
-The propagation system also enables two kinds of warnings:
+After propagation, two diagnostic passes run:
 
-1. **Unprovided constraints** — when propagation discovers a requirement Specimen can't emit (e.g. `[MyHashable α]`), it warns the user. Specimen can only provide `Arbitrary`, `Enum`, and `DecidableEq`.
+1. **Unprovided constraints**: if propagation discovers a class Specimen can't emit (anything other than `Arbitrary`, `Enum`, `DecidableEq`), a warning tells the user what's missing. This catches cases like a custom `[MyHashable α]` that Specimen doesn't know how to add to the generated signature.
 
-2. **Missing concrete instances** — when a schedule step references a concrete type (no type params) but the required instance doesn't exist (e.g. `[Arbitrary MyColor]` with no such instance defined), Specimen warns rather than silently generating broken code.
+2. **Missing concrete instances**: for each schedule step referencing a concrete type (no type params, not being derived in this call), verify the required instance actually exists. If not, warn — e.g. "needs `[Arbitrary MyColor]` but no such instance exists."
 
 ## Display
 
-Computed constraints appear in two places:
-- **Spec labels** in the HTML widget and text output: `Generator Between{Arbitrary, DecidableEq}[0,2]`
-- **Generated code dropdown** in the HTML widget: shows the actual emitted definition with its instance binders
+Computed constraints are shown in:
+- **Spec labels** in both text output and HTML widget: e.g. `Generator Between{Arbitrary, DecidableEq}[0,2]`
+- **Generated code dropdown** in the HTML widget: the actual emitted `def` with instance binders visible
+- **logInfo suppression**: per-component log messages are suppressed when `richOutput` is active (the HTML widget shows everything more clearly)

--- a/Docs/Constraint-propagation.md
+++ b/Docs/Constraint-propagation.md
@@ -1,0 +1,69 @@
+# Constraint Propagation for Polymorphic Dependencies
+
+## Problem
+
+When Specimen generates code for a polymorphic type like `GenList (α : Type) [Arbitrary α]`, the generated definition needs the right typeclass constraints on its type parameters. Previously, constraints were hardcoded per derive-sort: generators always got `[Arbitrary α]`, checkers always got `[Enum α, DecidableEq α]`. This caused two issues:
+
+1. **Unused constraints** — generators got `[Enum α]` they didn't need.
+2. **Missing constraints** — when a generator depends on a checker that shares a type parameter, the generator's hardcoded constraints didn't include `[Enum α]`, so the checker call inside the generated code couldn't find its required instance.
+
+## Solution: Bottom-Up Propagation
+
+Replace hardcoded constraints with a bottom-up walk through the dependency graph that discovers what each spec *actually needs*.
+
+### Algorithm
+
+After SCC decomposition gives us components in topological order (leaves first):
+
+```
+for each component (in topo order):
+  if singleton:
+    compute constraints by walking schedule steps
+  if mutual block:
+    fixed-point iteration until stable
+```
+
+For each schedule step, we determine constraints by its kind:
+
+| Step kind | Source of constraints |
+|-----------|---------------------|
+| `Unconstrained (NonRec)` on a bare type param | Own-sort class directly (`Arbitrary`/`Enum`) |
+| `Unconstrained (NonRec)` on a compound type | Synthesis: try `synth [TC (Foo α)]`, read back what the instance needs |
+| `Check (NonRec)` for Eq/Ne | `DecidableEq` (special case) |
+| `Check (NonRec)` for other relations | Look up internal dep map, else synthesize `DecOpt` |
+| `SuchThat (NonRec)` | Look up internal dep map, else synthesize `ArbitrarySizedSuchThat`/`EnumSizedSuchThat` |
+| `Rec` / self-recursive | No-op (constraints come from non-recursive steps) |
+| `MutRec` sibling | Look up sibling's current constraints (fixed-point) |
+
+### Key design decisions
+
+**Why synthesis for external deps?** When a spec depends on something already in the environment (e.g. `Arbitrary (List α)`), we can't inspect its schedule—it doesn't have one. Instead we ask Lean's instance synthesis to find it, then read the instance's type signature to discover what constraints it required (e.g. `[Arbitrary α]`).
+
+**Why fixed-point for mutual blocks?** In a mutual group, spec A might depend on spec B and vice versa. We iterate: compute A's constraints assuming B's current set, then B's assuming A's, repeat until neither changes.
+
+**Why always add `DecidableEq`?** If a spec has *any* constraints, it almost certainly needs `DecidableEq` too (for equality checks in the generated code). Rather than track this precisely, we add it unconditionally when the constraint set is non-empty.
+
+### Implementation
+
+Core functions in `Specimen/DeriveConstrainedProducer.lean`:
+
+- `extractTypeParamRefs` — walks a `ConstructorExpr` tree to find which type params it references
+- `synthExternalConstraints` — synthesizes an instance for a compound type and reads back the constraints from the instance's type signature
+- `computeSpecConstraints` — computes constraints for a single spec given the already-computed dep map
+- `propagateConstraints` — orchestrates the full bottom-up walk across all components
+
+The computed constraints are passed to `compileInductiveSchedule` which emits them as instance binders in the generated definition.
+
+## Diagnostics
+
+The propagation system also enables two kinds of warnings:
+
+1. **Unprovided constraints** — when propagation discovers a requirement Specimen can't emit (e.g. `[MyHashable α]`), it warns the user. Specimen can only provide `Arbitrary`, `Enum`, and `DecidableEq`.
+
+2. **Missing concrete instances** — when a schedule step references a concrete type (no type params) but the required instance doesn't exist (e.g. `[Arbitrary MyColor]` with no such instance defined), Specimen warns rather than silently generating broken code.
+
+## Display
+
+Computed constraints appear in two places:
+- **Spec labels** in the HTML widget and text output: `Generator Between{Arbitrary, DecidableEq}[0,2]`
+- **Generated code dropdown** in the HTML widget: shows the actual emitted definition with its instance binders

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -937,11 +937,289 @@ private def compileWeightedProducer
   | .Enumerator => pure subProducer
   | .Checker | .Theorem => `(fun (_ : Unit) => $subProducer)
 
+/-- Walk a ConstructorExpr tree and collect which type params it references. -/
+def extractTypeParamRefs (typeParams : Std.HashSet Name) : ConstructorExpr → Std.HashSet Name
+  | .Unknown n => if typeParams.contains n then Std.HashSet.ofList [n] else {}
+  | .Ctor _ args | .TyCtor _ args | .FuncApp _ args =>
+    args.foldl (fun acc a => acc.union (extractTypeParamRefs typeParams a)) {}
+  | .Lit _ | .CSort _ | .Hole => {}
+
+/-- Synthesize `[tcName type]` for a compound type and extract what constraints the
+    instance requires on Sort-typed params. Used for external deps (already in env). -/
+private partial def synthExternalConstraints (indName : Name) (args : List ConstructorExpr)
+    (typeParamNames : Array Name) (tcName : Name)
+    (outputVarNames : List Name := []) : TermElabM (Array Name) := do
+  let depIndInfo ← try getConstInfoInduct indName
+    catch _ =>
+      if typeParamNames.contains indName then
+        match tcName with
+        | ``Plausible.Arbitrary => return #[``Plausible.Arbitrary]
+        | ``Enum => return #[``Enum]
+        | _ => return #[]
+      return #[]
+  let depArgTypes ← getComponentsOfArrowType depIndInfo.type
+  let depArgTypes := depArgTypes.pop
+  let mut touches := false
+  for i in [:args.length] do
+    match args[i]! with
+    | .Unknown varName =>
+      if typeParamNames.contains varName then
+        if let some argTy := depArgTypes[i]? then
+          if argTy.isSort then touches := true
+    | _ => pure ()
+  if !touches then return #[]
+  Meta.withNewMCtxDepth do
+    let indLevels ← depIndInfo.levelParams.mapM (fun _ => do
+      let lv ← Meta.mkFreshLevelMVar; pure (.succ lv))
+    let numArgs := depArgTypes.size
+    let outputIndices := computeOutputIndices args outputVarNames
+    let rec buildSynth (idx : Nat) (t : Expr) (fvars : Array Expr) (instIdx : Nat)
+        : TermElabM (Array Name) :=
+      if idx >= numArgs then do
+        let body := mkAppN (.const indName indLevels) fvars
+        let instTy ←
+          if tcName == ``DecOpt then
+            mkAppM tcName #[body]
+          else if tcName == ``Plausible.Arbitrary || tcName == ``Enum then
+            -- For base-type generation: just synthesize the class on the full applied type
+            mkAppM tcName #[body]
+          else
+            -- ArbitrarySizedSuchThat / EnumSizedSuchThat: need predicate form
+            let outputFVars := outputIndices.filterMap (fun i => fvars[i]?)
+            if outputFVars.isEmpty then mkAppM tcName #[body]
+            else
+              let outputTypes ← outputFVars.mapM (fun e => inferType e)
+              let outType ← tupleOfListM (throwError "empty")
+                (fun t' rest => do
+                  let u ← Meta.mkFreshLevelMVar
+                  let v ← Meta.mkFreshLevelMVar
+                  pure (Lean.mkApp2 (Lean.mkConst ``Prod [u, v]) t' rest)) outputTypes
+              withLocalDecl `x .default outType fun xFvar => do
+                let mut projections : Array Expr := #[]
+                let mut currentExpr := xFvar
+                for i in [:outputFVars.length] do
+                  if outputFVars.length == 1 then projections := projections.push currentExpr
+                  else if i < outputFVars.length - 1 then
+                    projections := projections.push (.proj ``Prod 0 currentExpr)
+                    currentExpr := .proj ``Prod 1 currentExpr
+                  else projections := projections.push currentExpr
+                let mut finalArgs : Array Expr := #[]
+                let mut oi := 0
+                for i in [:numArgs] do
+                  if i ∈ outputIndices then
+                    finalArgs := finalArgs.push projections[oi]!
+                    oi := oi + 1
+                  else
+                    finalArgs := finalArgs.push fvars[i]!
+                let predBody := mkAppN (.const indName indLevels) finalArgs
+                let pred ← mkLambdaFVars #[xFvar] predBody
+                mkAppM tcName #[outType, pred]
+        match ← Meta.synthInstance? instTy with
+        | some inst =>
+          -- Get the actual constant name of the instance to inspect its global type
+          let instConst := inst.getAppFn
+          let mut cs : Array Name := #[]
+          if let some constName := instConst.constName? then
+            if let some cinfo := (← getEnv).find? constName then
+              let mut ty := cinfo.type
+              while ty.isForall do
+                if ty.bindingInfo! == .instImplicit then
+                  let domain := ty.bindingDomain!
+                  if let some cn := domain.getAppFn.constName? then
+                    if !cs.contains cn then
+                      cs := cs.push cn
+                ty := ty.bindingBody!
+          let mut ty := instTy
+          while ty.isForall do
+            if ty.bindingInfo! == .instImplicit then
+              let domain := ty.bindingDomain!
+              if let some cn := domain.getAppFn.constName? then
+                if !cs.contains cn then
+                  cs := cs.push cn
+            ty := ty.bindingBody!
+          return cs
+        | none =>
+          return #[]
+      else do
+        let argTy := (← inferType t).bindingDomain!
+        let name := Name.mkSimple s!"arg_{idx}"
+        let bi := if argTy.isSort then BinderInfo.implicit else .default
+        withLocalDecl name bi argTy fun fv => do
+          if argTy.isSort then
+            let enumTy ← mkAppM ``Enum #[fv]
+            let arbTy ← mkAppM ``Plausible.Arbitrary #[fv]
+            let decEqTy ← mkAppM ``DecidableEq #[fv]
+            withLocalDecl (Name.mkSimple s!"inst_enum_{instIdx}") .instImplicit enumTy fun _ =>
+            withLocalDecl (Name.mkSimple s!"inst_arb_{instIdx}") .instImplicit arbTy fun _ =>
+            withLocalDecl (Name.mkSimple s!"inst_deceq_{instIdx}") .instImplicit decEqTy fun _ =>
+              buildSynth (idx + 1) (.app t fv) (fvars.push fv) (instIdx + 1)
+          else
+            buildSynth (idx + 1) (.app t fv) (fvars.push fv) instIdx
+    try buildSynth 0 (.const indName indLevels) #[] 0
+    catch _ => pure #[]
+
+/-- Compute constraints for a single spec given a map of already-computed dep constraints.
+    `depConstraintMap` contains constraints for internal deps (specs in the same derive_mutual).
+    For external deps (not in the map), uses synthesis to discover constraints.
+
+    `siblingConstraints` is used for mutual-block fixed-point: the current iteration's
+    constraints for sibling specs in the same SCC. Pass `none` for non-mutual specs. -/
+def computeSpecConstraints (indSched : InductiveSchedule)
+    (typeParamNames : Array Name) (ownDeriveSort : DeriveSort)
+    (depConstraintMap : Std.HashMap SpecKey (Array Name))
+    (siblingConstraints : Option (Std.HashMap SpecKey (Array Name)) := none)
+    : TermElabM (Array Name) := do
+  if typeParamNames.isEmpty then return #[]
+  let typeParamSet := Std.HashSet.ofArray typeParamNames
+  let mut constraints : Std.HashSet Name := {}
+  let allScheds := indSched.baseSchedules ++ indSched.recSchedules
+  let allSteps := allScheds.flatMap (fun (_, (steps, _)) => steps)
+  for step in allSteps do
+    match step with
+    | .Unconstrained _ (.NonRec (indName, args)) ps =>
+      let tcName := match ps with
+        | .Generator => ``Plausible.Arbitrary
+        | .Enumerator => ``Enum
+      -- Check if any type param is referenced (directly or nested)
+      let refs := args.foldl (fun acc a => acc.union (extractTypeParamRefs typeParamSet a)) ({} : Std.HashSet Name)
+      if indName == tcName then
+        pure ()  -- shouldn't happen, but guard
+      else if typeParamNames.contains indName then
+        -- Bare type param: add own-sort class directly
+        constraints := constraints.insert tcName
+      else if !refs.isEmpty then
+        -- Compound type containing type params: synthesis to discover requirements
+        let found ← synthExternalConstraints indName args typeParamNames tcName
+        for c in found do constraints := constraints.insert c
+    | .Unconstrained _ (.Rec ..) _ => pure ()
+    | .Unconstrained _ (.MutRec sibName _) _ =>
+      if let some sibs := siblingConstraints then
+        let sibKey : SpecKey := { inductiveName := sibName, outputIndices := [], deriveSort := ownDeriveSort }
+        if let some sibCs := sibs[sibKey]? then
+          for c in sibCs do constraints := constraints.insert c
+    | .Check (.NonRec (indName, args)) _ =>
+      let refs := args.foldl (fun acc a => acc.union (extractTypeParamRefs typeParamSet a)) ({} : Std.HashSet Name)
+      if !refs.isEmpty then
+        -- Eq/Ne checks require DecidableEq on the type param
+        if indName == ``Eq || indName == ``Ne then
+          constraints := constraints.insert ``DecidableEq
+        else
+          -- Look up dep constraints from our map first (internal dep)
+          let depKey : SpecKey := { inductiveName := indName, outputIndices := [], deriveSort := .Checker }
+          match depConstraintMap[depKey]? with
+          | some depCs => for c in depCs do constraints := constraints.insert c
+          | none =>
+            -- Check sibling constraints (mutual block)
+            let fromSibling := siblingConstraints.bind (·[depKey]?)
+            match fromSibling with
+            | some depCs => for c in depCs do constraints := constraints.insert c
+            | none =>
+              -- External dep: use synthesis
+              let found ← synthExternalConstraints indName args typeParamNames ``DecOpt
+              if found.isEmpty then
+                -- Synthesis failed; fall back to checker defaults
+                constraints := constraints.insert ``Enum |>.insert ``DecidableEq
+              else
+                for c in found do constraints := constraints.insert c
+    | .Check (.Rec ..) _ => pure ()
+    | .Check (.MutRec sibName _) _ =>
+      if let some sibs := siblingConstraints then
+        let sibKey : SpecKey := { inductiveName := sibName, outputIndices := [], deriveSort := .Checker }
+        if let some sibCs := sibs[sibKey]? then
+          for c in sibCs do constraints := constraints.insert c
+    | .SuchThat _ (.NonRec (indName, args)) ps =>
+      let refs := args.foldl (fun acc a => acc.union (extractTypeParamRefs typeParamSet a)) ({} : Std.HashSet Name)
+      if !refs.isEmpty then
+        let ds := match ps with | .Generator => DeriveSort.Generator | .Enumerator => .Enumerator
+        let outputIndices := computeOutputIndices args
+          ((match step with | .SuchThat vs _ _ => vs.map Prod.fst | _ => []))
+        let depKey : SpecKey := { inductiveName := indName, outputIndices := outputIndices, deriveSort := ds }
+        match depConstraintMap[depKey]? with
+        | some depCs => for c in depCs do constraints := constraints.insert c
+        | none =>
+          let fromSibling := siblingConstraints.bind (·[depKey]?)
+          match fromSibling with
+          | some depCs => for c in depCs do constraints := constraints.insert c
+          | none =>
+            let tcName := match ps with
+              | .Generator => ``ArbitrarySizedSuchThat
+              | .Enumerator => ``EnumSizedSuchThat
+            let outNames := match step with | .SuchThat vs _ _ => vs.map Prod.fst | _ => []
+            let found ← synthExternalConstraints indName args typeParamNames tcName outNames
+            for c in found do constraints := constraints.insert c
+    | .SuchThat _ (.Rec ..) _ => pure ()
+    | .SuchThat _ (.MutRec sibName _) _ =>
+      if let some sibs := siblingConstraints then
+        let sibKey : SpecKey := { inductiveName := sibName, outputIndices := [], deriveSort := ownDeriveSort }
+        if let some sibCs := sibs[sibKey]? then
+          for c in sibCs do constraints := constraints.insert c
+    | _ => pure ()
+  if !constraints.isEmpty then
+    constraints := constraints.insert ``DecidableEq
+  return constraints.toArray
+
+/-- Bottom-up constraint propagation across all specs in a derive_mutual call.
+    Components are in topological order (leaves first), so when we process a spec,
+    all its non-mutual deps already have their constraints computed.
+    For mutual blocks, uses fixed-point iteration until stable. -/
+def propagateConstraints (components : List (List SpecKey))
+    (memo : Std.HashMap SpecKey MemoEntry) : TermElabM (Std.HashMap SpecKey (Array Name)) := do
+  let mut result : Std.HashMap SpecKey (Array Name) := {}
+  for comp in components do
+    if comp.length == 1 then
+      -- Single-spec component: compute directly using already-computed dep constraints
+      let key := comp.head!
+      match memo[key]? with
+      | some (.done indSched) =>
+        if indSched.alreadyExists then
+          result := result.insert key #[]
+        else
+          let indInfo ← getConstInfoInduct key.inductiveName
+          let argTypes ← getComponentsOfArrowType indInfo.type
+          let argTypes := argTypes.pop
+          let argNames := indSched.argNames
+          let typeParamNames := (List.range argTypes.size).filterMap fun i =>
+            if let some ty := argTypes[i]? then
+              if ty.isSort then argNames[i]? else none
+            else none
+          let cs ← computeSpecConstraints indSched typeParamNames.toArray key.deriveSort result
+          result := result.insert key cs
+      | _ => result := result.insert key #[]
+    else
+      -- Mutual block: fixed-point iteration
+      let mut sibMap : Std.HashMap SpecKey (Array Name) := {}
+      for key in comp do sibMap := sibMap.insert key #[]
+      let mut changed := true
+      while changed do
+        changed := false
+        for key in comp do
+          match memo[key]? with
+          | some (.done indSched) =>
+            if indSched.alreadyExists then continue
+            let indInfo ← getConstInfoInduct key.inductiveName
+            let argTypes ← getComponentsOfArrowType indInfo.type
+            let argTypes := argTypes.pop
+            let argNames := indSched.argNames
+            let typeParamNames := (List.range argTypes.size).filterMap fun i =>
+              if let some ty := argTypes[i]? then
+                if ty.isSort then argNames[i]? else none
+              else none
+            let cs ← computeSpecConstraints indSched typeParamNames.toArray key.deriveSort result (some sibMap)
+            if cs != (sibMap[key]?.getD #[]) then
+              changed := true
+              sibMap := sibMap.insert key cs
+          | _ => pure ()
+      -- Copy converged sibling constraints into result
+      for (key, cs) in sibMap.toList do
+        result := result.insert key cs
+  return result
+
 /-- Compiles an InductiveSchedule from the memo into (def, instance) commands.
     Uses the pre-derived schedules directly (no re-derivation).
     `siblings` is the list of specs in the same mutual block (for rewriting to Source.MutRec). -/
 def compileInductiveSchedule (indSched : InductiveSchedule)
     (globalName : Name) (siblings : List (Name × List Nat × Name × DeriveSort))
+    (requiredConstraints : Option (Array Name) := none)
     : TermElabM (TSyntax `command × TSyntax `command) := do
   let key := indSched.key
   let indInfo ← getConstInfoInduct key.inductiveName
@@ -1049,9 +1327,10 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
     let mut paramInfo : Array (Name × Expr × TSyntax `term) := #[]
     for i in [:liveTypes.size] do
       paramInfo := paramInfo.push (argNames.getD i `x, liveTypes[i]!, liveTypesSyntax[i]!)
-    mkConstrainedProducerMutualPieces baseProducers inductiveProducers
+    mkConstrainedProducerMutualPieces
+      baseProducers inductiveProducers
       key.inductiveName indLevels freshArgIdents freshenedOutputNames
-      outputTypes producerSort (← getLCtx) globalName key.deriveSort paramInfo
+      outputTypes producerSort (← getLCtx) globalName key.deriveSort (some paramInfo) requiredConstraints
 
 /-- Recursively derives the best schedule for a SpecKey, populating the memo with
     all transitive dependencies. Returns the score for this spec.
@@ -1779,7 +2058,157 @@ def elabDeriveMutual : CommandElab := fun stx => do
               |>.filter (usedKeys.contains ·) |>.eraseDups
             totalEdges := totalEdges + depKeys.length
           | _ => pure ()
-        -- Compile all components BEFORE building the widget so we can show generated code
+        -- Propagate constraints and compile all specs (before HTML so generated code can be shown)
+        let constraintMap ← liftTermElabM <| propagateConstraints components finalMemo
+        -- Compute type param indices per spec and detect instance-param constraints (for display)
+        let mut typeParamIdxMap : Std.HashMap SpecKey (Array Nat) := {}
+        let mut displayConstraintMap := constraintMap
+        for (key, _) in constraintMap.toList do
+          let (idxs, extraCs) ← liftTermElabM do
+            try
+              let indInfo ← getConstInfoInduct key.inductiveName
+              let argTypes ← getComponentsOfArrowType indInfo.type
+              let argTypes := argTypes.pop
+              let mut sortIdxs : Array Nat := #[]
+              let mut instConstraints : Array Name := #[]
+              for i in [:argTypes.size] do
+                let ty := argTypes[i]!
+                if ty.isSort then
+                  sortIdxs := sortIdxs.push i
+                else
+                  -- Check if this param's type is a typeclass applied to a type param
+                  let fn := ty.getAppFn
+                  if fn.isConst then
+                    if let some tcName := fn.constName? then
+                      if (← Meta.isClass? ty).isSome then
+                        if !instConstraints.contains tcName then
+                          instConstraints := instConstraints.push tcName
+              pure (sortIdxs, instConstraints)
+            catch _ => pure (#[], #[])
+          typeParamIdxMap := typeParamIdxMap.insert key idxs
+          if !extraCs.isEmpty then
+            let existing := displayConstraintMap[key]?.getD #[]
+            let merged := existing ++ extraCs.filter (!existing.contains ·)
+            displayConstraintMap := displayConstraintMap.insert key merged
+        -- Warn about required constraints that Specimen cannot provide
+        let providedConstraints : Std.HashSet Name := Std.HashSet.ofList
+          [``Plausible.Arbitrary, ``Enum, ``DecidableEq]
+        for (key, cs) in constraintMap.toList do
+          if cs.isEmpty then continue
+          let numArgs ← liftTermElabM do
+            try pure ((← getComponentsOfArrowType (← getConstInfoInduct key.inductiveName).type).size - 1)
+            catch _ => pure key.outputIndices.length
+          let missing := cs.filter (fun c => !providedConstraints.contains c)
+          if !missing.isEmpty then
+            let missingStrs : Array String := missing.map Name.getString!
+            let providedStrs : Array String := cs.filter providedConstraints.contains |>.map Name.getString!
+            logWarning m!"derive_mutual: {key.prettyPrint numArgs} requires [{String.intercalate ", " (cs.map Name.getString!).toList}] but Specimen can only provide [{String.intercalate ", " providedStrs.toList}]. Missing: [{String.intercalate ", " missingStrs.toList}]"
+        -- Check for missing concrete instances (e.g. Enum Nat, DecOpt (Foo 1 2))
+        for key in usedKeys.toList do
+          match finalMemo[key]? with
+          | some (.done indSched) =>
+            if indSched.alreadyExists then continue
+            let allScheds := indSched.baseSchedules ++ indSched.recSchedules
+            let allSteps := allScheds.flatMap (fun (_, (steps, _)) => steps)
+            let indArgNames := indSched.argNames
+            let tpArgNames : Std.HashSet Name := Std.HashSet.ofArray (typeParamIdxMap[key]?.getD #[] |>.filterMap fun i =>
+              indArgNames[i]?)
+            for step in allSteps do
+              match step with
+              | .Unconstrained _ (.NonRec (indName, args)) ps =>
+                -- Skip if involves type params or is being derived in this call
+                let hasTP := args.any fun a => match a with
+                  | .Unknown n => tpArgNames.contains n
+                  | _ => false
+                let isInternal := usedKeys.toList.any (·.inductiveName == indName)
+                if !hasTP && !isInternal then
+                  let tcName := match ps with
+                    | .Generator => ``Plausible.Arbitrary
+                    | .Enumerator => ``Enum
+                  let instExists ← liftTermElabM <| Meta.withNewMCtxDepth do
+                    try
+                      let depInfo ← getConstInfoInduct indName
+                      let indLevels ← depInfo.levelParams.mapM (fun _ => do
+                        let lv ← Meta.mkFreshLevelMVar; pure (.succ lv))
+                      let depArgTypes ← getComponentsOfArrowType depInfo.type
+                      let depArgTypes := depArgTypes.pop
+                      let mut ty := Lean.mkConst indName indLevels
+                      for _ in [:depArgTypes.size] do
+                        let argTy := (← inferType ty).bindingDomain!
+                        let mvar ← Meta.mkFreshExprMVar argTy
+                        ty := .app ty mvar
+                      let instTy ← mkAppM tcName #[ty]
+                      return (← Meta.synthInstance? instTy).isSome
+                    catch _ => pure true
+                  if !instExists then
+                    let numArgs ← liftTermElabM do
+                      try pure ((← getComponentsOfArrowType (← getConstInfoInduct key.inductiveName).type).size - 1)
+                      catch _ => pure key.outputIndices.length
+                    let argsStr := String.intercalate " " (args.map ppConstructorExpr)
+                    let typeStr := if args.isEmpty then s!"{indName}" else s!"{indName} {argsStr}"
+                    logWarning m!"derive_mutual: {key.prettyPrint numArgs} needs [{tcName.getString!} ({typeStr})] but no such instance exists"
+              | .Check (.NonRec (indName, args)) _ =>
+                let hasTP := args.any fun a => match a with
+                  | .Unknown n => tpArgNames.contains n
+                  | _ => false
+                let isInternal := usedKeys.toList.any (·.inductiveName == indName)
+                if !hasTP && !isInternal then
+                  -- Check if DecOpt instance exists for this concrete relation
+                  let instExists ← liftTermElabM <| Meta.withNewMCtxDepth do
+                    try
+                      let depInfo ← getConstInfoInduct indName
+                      let indLevels ← depInfo.levelParams.mapM (fun _ => do
+                        let lv ← Meta.mkFreshLevelMVar; pure (.succ lv))
+                      let numArgs := (← getComponentsOfArrowType depInfo.type).size - 1
+                      let mut ty := Lean.mkConst indName indLevels
+                      for _ in [:numArgs] do
+                        let argTy := (← inferType ty).bindingDomain!
+                        let mvar ← Meta.mkFreshExprMVar argTy
+                        ty := .app ty mvar
+                      let instTy ← mkAppM ``DecOpt #[ty]
+                      return (← Meta.synthInstance? instTy).isSome
+                    catch _ => pure true
+                  if !instExists then
+                    let numArgs ← liftTermElabM do
+                      try pure ((← getComponentsOfArrowType (← getConstInfoInduct key.inductiveName).type).size - 1)
+                      catch _ => pure key.outputIndices.length
+                    let argsStr := String.intercalate " " (args.map ppConstructorExpr)
+                    let typeStr := if args.isEmpty then s!"{indName}" else s!"{indName} {argsStr}"
+                    logWarning m!"derive_mutual: {key.prettyPrint numArgs} needs [DecOpt ({typeStr})] but no such instance exists"
+              | .SuchThat _ (.NonRec (indName, args)) ps =>
+                let hasTP := args.any fun a => match a with
+                  | .Unknown n => tpArgNames.contains n
+                  | _ => false
+                let isInternal := usedKeys.toList.any (·.inductiveName == indName)
+                if !hasTP && !isInternal then
+                  let tcName := match ps with
+                    | .Generator => ``ArbitrarySizedSuchThat
+                    | .Enumerator => ``EnumSizedSuchThat
+                  let instExists ← liftTermElabM <| Meta.withNewMCtxDepth do
+                    try
+                      let depInfo ← getConstInfoInduct indName
+                      let indLevels ← depInfo.levelParams.mapM (fun _ => do
+                        let lv ← Meta.mkFreshLevelMVar; pure (.succ lv))
+                      let numArgs := (← getComponentsOfArrowType depInfo.type).size - 1
+                      let mut ty := Lean.mkConst indName indLevels
+                      for _ in [:numArgs] do
+                        let argTy := (← inferType ty).bindingDomain!
+                        let mvar ← Meta.mkFreshExprMVar argTy
+                        ty := .app ty mvar
+                      -- Try synthesizing as a simple application (for concrete types)
+                      let instTy ← mkAppM tcName #[ty, ← Meta.mkFreshExprMVar none]
+                      return (← Meta.synthInstance? instTy).isSome
+                    catch _ => pure true
+                  if !instExists then
+                    let sortStr := match ps with | .Generator => "ArbitrarySizedSuchThat" | .Enumerator => "EnumSizedSuchThat"
+                    let numArgs ← liftTermElabM do
+                      try pure ((← getComponentsOfArrowType (← getConstInfoInduct key.inductiveName).type).size - 1)
+                      catch _ => pure key.outputIndices.length
+                    let argsStr := String.intercalate " " (args.map ppConstructorExpr)
+                    let typeStr := if args.isEmpty then s!"{indName}" else s!"{indName} {argsStr}"
+                    logWarning m!"derive_mutual: {key.prettyPrint numArgs} needs [{sortStr} ({typeStr})] but no such instance exists"
+              | _ => pure ()
+          | _ => pure ()
         let mut compiledComponents : Array (Array (SpecKey × Name) × Array (TSyntax `command) × Array (TSyntax `command)) := #[]
         let mut compiledCodeMap : Std.HashMap SpecKey (String × String) := {}
         for comp in components do
@@ -1797,8 +2226,9 @@ def elabDeriveMutual : CommandElab := fun stx => do
             | some (.done indSched) =>
               if indSched.alreadyExists then continue
               try
+                let specConstraints := constraintMap[key]?
                 let (defCmd, instCmd) ← liftTermElabM <|
-                  compileInductiveSchedule indSched globalName compSiblings
+                  compileInductiveSchedule indSched globalName compSiblings specConstraints
                 defCmds := defCmds.push defCmd
                 instCmds := instCmds.push instCmd
                 let defStr ← liftTermElabM <| try
@@ -1930,9 +2360,11 @@ def elabDeriveMutual : CommandElab := fun stx => do
                       .element "div" #[("style", codeStyle)] #[.text (defStr ++ "\n\n" ++ instStr)]
                     ]]
                   | none => #[]
+                let cs := displayConstraintMap[k]?.getD #[]
+                let tpIdxs := typeParamIdxMap[k]?.getD #[]
                 mutualItems := mutualItems.push (Html.element "details" #[] #[
                   .element "summary" #[("style", json% {"cursor": "pointer", "marginBottom": "2px"})] #[
-                    mkSpan specNameStyle (k.prettyPrint numArgs),
+                    mkSpan specNameStyle (k.prettyPrint numArgs cs tpIdxs),
                     mkSpan scoreStyle s!" ({nCtors} ctors{timeStr}) score: {indScoreStr}"
                   ],
                   .element "div" #[("style", json% {"marginLeft": "12px"})] (ctorItems ++ codeDropdown)
@@ -1969,10 +2401,12 @@ def elabDeriveMutual : CommandElab := fun stx => do
                       .element "div" #[("style", codeStyle)] #[.text (defStr ++ "\n\n" ++ instStr)]
                     ]]
                   | none => #[]
+                let cs := displayConstraintMap[k]?.getD #[]
+                let tpIdxs := typeParamIdxMap[k]?.getD #[]
                 orderItems := orderItems.push (Html.element "details" #[] #[
                   .element "summary" #[("style", json% {"cursor": "pointer", "marginBottom": "2px"})] #[
                     .text "● ",
-                    mkSpan specNameStyle (k.prettyPrint numArgs),
+                    mkSpan specNameStyle (k.prettyPrint numArgs cs tpIdxs),
                     mkSpan scoreStyle s!" ({nCtors} ctors{timeStr}) score: {indScoreStr}"
                   ],
                   .element "div" #[("style", json% {"marginLeft": "12px"})] (ctorItems ++ codeDropdown)
@@ -2120,13 +2554,13 @@ def elabDeriveMutual : CommandElab := fun stx => do
             ],
             .element "div" #[("style", json% {"marginLeft": "8px", "borderLeft": "2px solid #3c3c3c", "paddingLeft": "12px"})] trieItems
           ])
-        -- Emit the full HTML (if richOutput enabled)
+        -- Emit the full HTML widget (at top of infoview)
         if richOutput then
           let fullHtml := Html.element "div" #[("style", json% {"fontFamily": "var(--vscode-editor-font-family, monospace)", "fontSize": "13px", "lineHeight": "1.6", "padding": "8px"})] htmlChildren
           let graphMsg ← liftCoreM <| Lean.MessageData.ofHtml fullHtml
             s!"derive_mutual: {usedKeys.size} specs in {components.length} components"
           logInfo graphMsg
-        -- Plain-text output (accessible to LLMs and non-IDE tooling)
+        -- Plain-text fallback output (accessible to LLMs and non-IDE tooling)
         -- Levels: 0=off, 1=names+quality, 2=full schedules for poor-quality, 3=everything
         let textLevel := Lean.Option.get (← getOptions) specimen.textOutput
         if textLevel > 0 then
@@ -2150,7 +2584,9 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 match finalMemo[k]? with
                 | some (.done indSched) =>
                   let nCtors := indSched.baseSchedules.length + indSched.recSchedules.length
-                  lines := lines.push s!"    {specQuality indSched} {k.prettyPrint numArgs} ({nCtors} ctors) [{bundle.reprScore indSched.score}]"
+                  let cs := displayConstraintMap[k]?.getD #[]
+                  let tpIdxs := typeParamIdxMap[k]?.getD #[]
+                  lines := lines.push s!"    {specQuality indSched} {k.prettyPrint numArgs cs tpIdxs} ({nCtors} ctors) [{bundle.reprScore indSched.score}]"
                   if showSchedules indSched then
                     let allScheds := indSched.baseSchedules ++ indSched.recSchedules
                     for (ctorName, schedule) in allScheds do
@@ -2171,7 +2607,9 @@ def elabDeriveMutual : CommandElab := fun stx => do
                   lines := lines.push s!"  ● {k.prettyPrint numArgs} (pre-existing)"
                 else
                   let nCtors := indSched.baseSchedules.length + indSched.recSchedules.length
-                  lines := lines.push s!"  ● {specQuality indSched} {k.prettyPrint numArgs} ({nCtors} ctors) [{bundle.reprScore indSched.score}]"
+                  let cs := displayConstraintMap[k]?.getD #[]
+                  let tpIdxs := typeParamIdxMap[k]?.getD #[]
+                  lines := lines.push s!"  ● {specQuality indSched} {k.prettyPrint numArgs cs tpIdxs} ({nCtors} ctors) [{bundle.reprScore indSched.score}]"
                   if showSchedules indSched then
                     let allScheds := indSched.baseSchedules ++ indSched.recSchedules
                     for (ctorName, schedule) in allScheds do
@@ -2240,13 +2678,16 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 if indSched.alreadyExists then "(pre-existing)"
                 else s!"({indSched.baseSchedules.length} base, {indSched.recSchedules.length} rec)"
               | _ => ""
-            pure s!"{k.prettyPrint numArgs} {scoreStr}"
+            let cs := displayConstraintMap[k]?.getD #[]
+            let tpIdxs := typeParamIdxMap[k]?.getD #[]
+            pure s!"{k.prettyPrint numArgs cs tpIdxs} {scoreStr}"
+          let richOutput := Lean.Option.get (← getOptions) specimen.richOutput
           if defCmds.size > 1 then
-            logInfo m!"  ◆ mutual ({defCmds.size}):\n    {String.intercalate "\n    " specDescs}"
+            if !richOutput then logInfo m!"  ◆ mutual ({defCmds.size}):\n    {String.intercalate "\n    " specDescs}"
             let mutualCmd ← `(command| mutual $defCmds* end)
             elabCommand mutualCmd
           else if defCmds.size == 1 then
-            logInfo m!"  ● {specDescs.head!}"
+            if !richOutput then logInfo m!"  ● {specDescs.head!}"
             elabCommand defCmds[0]!
           for instCmd in instCmds do
             elabCommand instCmd

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1154,8 +1154,6 @@ def computeSpecConstraints (indSched : InductiveSchedule)
         if let some sibCs := sibs[sibKey]? then
           for c in sibCs do constraints := constraints.insert c
     | _ => pure ()
-  if !constraints.isEmpty then
-    constraints := constraints.insert ``DecidableEq
   return constraints.toArray
 
 /-- Bottom-up constraint propagation across all specs in a derive_mutual call.

--- a/Specimen/MakeConstrainedProducerInstance.lean
+++ b/Specimen/MakeConstrainedProducerInstance.lean
@@ -225,7 +225,8 @@ def mkConstrainedProducerMutualPieces
   (targetTypes : List Expr) (producerSort : ProducerSort)
   (topLevelLocalCtx : LocalContext) (globalDefName : Name)
   (deriveSort : DeriveSort)
-  (precomputedParamInfo : Option (Array (Name × Expr × TSyntax `term)) := none) :
+  (precomputedParamInfo : Option (Array (Name × Expr × TSyntax `term)) := none)
+  (requiredTypeClasses : Option (Array Name) := none) :
   TermElabM (TSyntax `command × TSyntax `command) := do
     -- Reuse the same computation as mkConstrainedProducerTypeClassInstance
     let freshSizeIdent := mkFreshAccessibleIdent topLevelLocalCtx `size
@@ -315,11 +316,15 @@ def mkConstrainedProducerMutualPieces
     for (name, ty) in allParamNamesAndTypes.reverse do
       fullType ← `(($name : $ty) → $fullType)
 
-    -- Add instance binders for type params (Arbitrary + DecidableEq)
-    let producerUnconstrainedClass := match producerSort with
-      | .Generator => ``Plausible.Arbitrary
-      | .Enumerator => ``Enum
-    let defTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
+    -- Add instance binders for type params
+    let typeClasses := match requiredTypeClasses with
+      | some tcs => tcs
+      | none =>
+        let producerUnconstrainedClass := match producerSort with
+          | .Generator => ``Plausible.Arbitrary
+          | .Enumerator => ``Enum
+        #[producerUnconstrainedClass, ``DecidableEq]
+    let defTypeParamInstances ← mkTypeClassInstanceBinders typeParams typeClasses
 
     -- Emit the def with ∀ type (supports instance binders inline)
     let defIdent := mkIdent globalDefName
@@ -346,9 +351,16 @@ def mkConstrainedProducerMutualPieces
     let fuelLit := Syntax.mkNumLit (toString fuelVal)
     let callArgs : TSyntaxArray `term := #[(⟨fuelLit⟩ : TSyntax `term), (freshSizeIdent : TSyntax `term), (freshSizeIdent : TSyntax `term)] ++ (TSyntaxArray.mk outerParams)
     let callExpr ← `($defIdent $callArgs*)
+    let instTypeClasses := match requiredTypeClasses with
+      | some tcs => tcs
+      | none => match deriveSort with
+        | .Checker | .Theorem => #[``Enum, ``DecidableEq]
+        | _ => match producerSort with
+          | .Generator => #[``Plausible.Arbitrary, ``DecidableEq]
+          | .Enumerator => #[``Enum, ``DecidableEq]
     let instCmd ← match deriveSort with
       | .Checker | .Theorem => do
-        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[``Enum, ``DecidableEq]
+        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams instTypeClasses
         `(command|
           instance $arbitraryTypeParamInstances:bracketedBinder* : $decOptTypeclass (@$(mkIdent inductiveName) $args*) where
             $unqualifiedDecOptFn:ident := fun $freshSizeIdent => $callExpr)
@@ -359,10 +371,7 @@ def mkConstrainedProducerMutualPieces
         let producerTypeClassFunction := match producerSort with
           | .Generator => unqualifiedArbitrarySizedSTFn
           | .Enumerator => unqualifiedEnumSizedSTFn
-        let producerUnconstrainedClass := match producerSort with
-          | .Generator => ``Plausible.Arbitrary
-          | .Enumerator => ``Enum
-        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams #[producerUnconstrainedClass, ``DecidableEq]
+        let arbitraryTypeParamInstances ← mkTypeClassInstanceBinders typeParams instTypeClasses
         `(command|
           instance $arbitraryTypeParamInstances:bracketedBinder* : $producerTypeClass $targetTypeSyntax (fun $targetVarPattern => @$(mkIdent inductiveName) $args*) where
             $producerTypeClassFunction:ident := fun $freshSizeIdent => $callExpr)

--- a/Specimen/Schedules.lean
+++ b/Specimen/Schedules.lean
@@ -450,7 +450,8 @@ structure SpecKey where
 
 /-- Pretty-prints a SpecKey as a spec form like "fun τ => ∃ Γ e, typing Γ e τ".
     Requires knowing the inductive's arg types (number of args). -/
-def SpecKey.prettyPrint (key : SpecKey) (numArgs : Nat) : String :=
+def SpecKey.prettyPrint (key : SpecKey) (numArgs : Nat)
+    (constraints : Array Name := #[]) (typeParamIndices : Array Nat := #[]) : String :=
   let varPool := #["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"]
   let (inputs, outputs, appArgs) := Id.run do
     let mut inputs : List String := []
@@ -464,7 +465,13 @@ def SpecKey.prettyPrint (key : SpecKey) (numArgs : Nat) : String :=
         inputs := inputs ++ [name]
       appArgs := appArgs ++ [name]
     (inputs, outputs, appArgs)
-  let inputsStr := if inputs.isEmpty then "" else s!"fun {String.intercalate " " inputs} => "
+  let constraintStr := if constraints.isEmpty || typeParamIndices.isEmpty then ""
+    else
+      let binders := typeParamIndices.toList.flatMap fun i =>
+        let varName := varPool.getD i s!"v{i}"
+        constraints.toList.map fun c => s!"[{c.getString!} {varName}]"
+      s!" {String.intercalate " " binders}"
+  let inputsStr := if inputs.isEmpty then "" else s!"fun {String.intercalate " " inputs}{constraintStr} => "
   let outputsStr := if outputs.isEmpty then "" else s!"∃ {String.intercalate " " outputs}, "
   let sortStr := match key.deriveSort with
     | .Generator => "[generator] "

--- a/SpecimenTest/PolymorphicDepConstraints.lean
+++ b/SpecimenTest/PolymorphicDepConstraints.lean
@@ -1,0 +1,118 @@
+import Specimen.DeriveConstrainedProducer
+import Specimen.DeriveChecker
+
+/-!
+# Regression test for issue #38: missing typeclass constraints for polymorphic dependencies
+
+When a generator depends on a checker sharing a type parameter, the generator must
+propagate the checker's constraints. Previously hardcoded; now computed bottom-up.
+-/
+
+open Plausible
+
+-- ============================================================
+-- Test 1: Basic — checker with Eq on type param propagates DecidableEq
+-- ============================================================
+
+inductive MyContains {α : Type} : α → List α → Prop where
+  | here : ∀ x rest, MyContains x (x :: rest)
+  | there : ∀ x y rest, MyContains x rest → MyContains x (y :: rest)
+
+inductive NotIn {α : Type} : α → List α → Prop where
+  | mk : ∀ x xs, ¬ MyContains x xs → NotIn x xs
+
+set_option specimen.autoDeriveDeps true in
+set_option specimen.multiOutput true in
+#guard_msgs(drop info) in
+derive_mutual
+  checker (fun α x xs => @MyContains α x xs),
+  generator (fun α xs => ∃ x, @NotIn α x xs)
+
+-- Generator only needs [Arbitrary α, DecidableEq α], NOT [Enum α]
+example : ∀ [Plausible.Arbitrary α] [DecidableEq α],
+    ArbitrarySizedSuchThat α (fun x => @NotIn α x xs) := inferInstance
+
+-- ============================================================
+-- Test 2: Compound type — generating List α propagates Arbitrary from List's instance
+-- ============================================================
+
+inductive AllEq {α : Type} : α → List α → Prop where
+  | nil : ∀ x, AllEq x []
+  | cons : ∀ x xs, AllEq x xs → AllEq x (x :: xs)
+
+inductive HasAllEq {α : Type} : List α → Prop where
+  | mk : ∀ x xs, AllEq x xs → HasAllEq (x :: xs)
+
+set_option specimen.autoDeriveDeps true in
+set_option specimen.multiOutput true in
+#guard_msgs(drop info) in
+derive_mutual
+  checker (fun α x xs => @AllEq α x xs),
+  generator (fun α => ∃ xs, @HasAllEq α xs)
+
+-- Generator needs [Arbitrary α, DecidableEq α] (Arbitrary for generating x, DecidableEq for Eq checks)
+example : ∀ [Plausible.Arbitrary α] [DecidableEq α],
+    ArbitrarySizedSuchThat (List α) (fun xs => @HasAllEq α xs) := inferInstance
+
+-- ============================================================
+-- Test 3: Generating List α unconstrainedly requires [Arbitrary α] transitively
+-- ============================================================
+
+inductive ListHead {α : Type} : α → List α → Prop where
+  | mk : ∀ x xs, ListHead x (x :: xs)
+
+inductive HasHead {α : Type} : List α → Prop where
+  | mk : ∀ (xs : List α) (x : α), ListHead x xs → HasHead xs
+
+set_option specimen.autoDeriveDeps true in
+set_option specimen.multiOutput true in
+#guard_msgs(drop info) in
+derive_mutual
+  checker (fun α x xs => @ListHead α x xs),
+  generator (fun α => ∃ ys, @HasHead α ys)
+
+-- The generator must discover [Arbitrary α] from generating List α unconstrainedly
+example : ∀ [Plausible.Arbitrary α] [DecidableEq α],
+    ArbitrarySizedSuchThat (List α) (fun ys => @HasHead α ys) := inferInstance
+
+-- ============================================================
+-- Test 4: Custom class — manual DecOpt instance with [MyHashable α] propagates up
+-- ============================================================
+
+class MyHashable (α : Type) where
+  myHash : α → UInt64
+
+inductive HashesTo {α : Type} [MyHashable α] : α → UInt64 → Prop where
+  | mk : ∀ (x : α), HashesTo x (MyHashable.myHash x)
+
+-- Manual checker instance that requires [MyHashable α]
+instance [MyHashable α] [DecidableEq UInt64] : DecOpt (@HashesTo α _ x h) where
+  decOpt := fun _ => if MyHashable.myHash x == h then .ok true else .ok false
+
+inductive ValidHash {α : Type} [MyHashable α] : α → Prop where
+  | mk : ∀ (x : α) (h : UInt64), HashesTo x h → ValidHash x
+
+set_option specimen.autoDeriveDeps true in
+set_option specimen.multiOutput true in
+#guard_msgs(drop info) in
+derive_mutual
+  generator (fun a b x => ∃ h, @HashesTo a b x h)
+
+-- ============================================================
+-- Test 5: Warning for missing concrete instances
+-- ============================================================
+
+inductive MyColor | Red | Green | Blue
+
+inductive HasColor : MyColor → Nat → Prop where
+  | mk : ∀ c n, HasColor c n
+
+/--
+warning: derive_mutual: [generator] fun b => ∃ a, HasColor a b needs [Arbitrary (MyColor)] but no such instance exists
+-/
+#guard_msgs(warning, drop error, drop info) in
+set_option specimen.autoDeriveDeps true in
+set_option specimen.multiOutput true in
+derive_mutual
+  checker (fun c n => HasColor c n),
+  generator (fun n => ∃ c, HasColor c n)


### PR DESCRIPTION
## Summary

Closes #38. When a generator depends on a checker sharing a type parameter, the generated code was missing constraints (e.g. `[Enum α]`) because they were hardcoded per derive-sort rather than propagated from dependencies.

Implements bottom-up constraint propagation through the dependency graph:
- After SCC decomposition (topological order, leaves first), compute required constraints per spec by walking schedule steps
- For internal deps: look up from the already-computed map
- For external deps: synthesis discovers transitive requirements (e.g. `Arbitrary (List α)` → `[Arbitrary α]`)
- For mutual blocks: fixed-point iteration until stable
- Self-recursive steps are no-ops; Eq/Ne special-cased to `DecidableEq`

Additionally, the same propagation system naturally enables:
- **Warning for missing concrete instances**: when propagation discovers a requirement that can't be satisfied (e.g. `[Arbitrary MyColor]` where no instance exists), Specimen now warns the user rather than silently generating broken code
- Generated code display in the derive_mutual HTML widget (foldable under each spec)
- Computed constraints shown inline in spec labels (`{Arbitrary, DecidableEq}`)
- Per-component logInfo suppressed when richOutput is active

## Test plan
- [x] `SpecimenTest/PolymorphicDepConstraints.lean` — 5 test cases:
  1. Basic: checker with Eq propagates only `{DecidableEq}` (not Enum)
  2. AllEq: compound relation propagates `{Arbitrary, DecidableEq}`
  3. List α: unconstrained generation discovers `{Arbitrary}` transitively
  4. HashesTo: custom class propagates `{MyHashable}` from manual DecOpt instance
  5. HasColor: warns when concrete instance is missing
- [x] Cedar reproducer: `cedar-spec/.../TestSetContainsBug.lean` derive_mutual succeeds
- [x] Existing tests pass: `ScheduleQualityRegressionTest`, `CedarCheckerGenerators`, `TestKeyValueStoreCheckerGenerators`