### PR TITLE
Add LawfulScorable scorer laws interface

### DIFF
--- a/Specimen/Scoring.lean
+++ b/Specimen/Scoring.lean
@@ -63,6 +63,40 @@ class Scorable (S : Type) where
   worst : S
   badness : S → Float
 
+/-- Laws expected from scoring strategies used by branch-and-bound search.
+
+`Scorable` stays executable and lightweight.  `LawfulScorable` packages the
+extra invariants required by proof-carrying uses of scoring strategies. -/
+class LawfulScorable (S : Type) [Scorable S] : Prop where
+  /-- Adding combined work to a score should not strictly improve it. -/
+  not_isBetter_combine_left :
+    ∀ a b : S, ¬ Scorable.isBetter (S := S) (Scorable.combine (S := S) a b) a
+
+  /-- Strict score comparison should be transitive. -/
+  isBetter_trans :
+    ∀ a b c : S,
+      Scorable.isBetter (S := S) a b →
+      Scorable.isBetter (S := S) b c →
+      Scorable.isBetter (S := S) a c
+
+  /-- `empty` is a left identity for `combine`. -/
+  empty_combine :
+    ∀ a : S, Scorable.combine (S := S) (Scorable.empty (S := S)) a = a
+
+  /-- `empty` is a right identity for `combine`. -/
+  combine_empty :
+    ∀ a : S, Scorable.combine (S := S) a (Scorable.empty (S := S)) = a
+
+  /-- The initial branch-and-bound sentinel should not beat a real candidate. -/
+  not_worst_isBetter :
+    ∀ a : S, ¬ Scorable.isBetter (S := S) (Scorable.worst (S := S)) a
+
+  /-- Scores that are better according to `isBetter` should not have worse visual badness. -/
+  badness_mono :
+    ∀ a b : S,
+      Scorable.isBetter (S := S) a b →
+      Scorable.badness (S := S) a ≤ Scorable.badness (S := S) b
+
 ----------------------------------------------
 -- Scorer function types (parameterized by score type)
 ----------------------------------------------


### PR DESCRIPTION
Draft progress for #45.

This PR adds a proof-carrying `LawfulScorable` interface next to the existing executable `Scorable` typeclass.

What is included:

- `combine` should not strictly improve the left score
- `isBetter` should be transitive
- `empty` should be a left and right identity for `combine`
- `worst` should not beat a real candidate
- `badness` should be monotone with `isBetter`

Local verification:

- `lake env lean Specimen/Scoring.lean` passes
- `lake build` passes

I kept this as a separate law class rather than modifying `Scorable`, so existing scoring strategies remain executable/lightweight and proof-carrying code can request the stronger interface explicitly.

Important design note: the issue text says `worst` must be worse than any real schedule. The current instances use finite sentinels such as `1000`, so a strong global law like “every score beats worst” may not hold for unbounded scores. This draft therefore uses the safer law “worst does not beat a candidate” while leaving open whether the final fix should use bounded laws or a true top sentinel.

Next step after feedback: add `LawfulScorable` instances or refine the `worst` law to match the intended branch-and-bound invariant.

Refs #45.
