### PR TITLE
Support scoped/local instance visibility for derive_mutual

### DIFF
--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1969,6 +1969,8 @@ def deriveFromScheduleDep (dep : ScheduleDep) (scheduleRewriter : List ScheduleS
       dep.inductiveName indLevels freshArgIdents freshenedOutputNames.toList
       outTypes.toList producerSort localCtx
 
+/-- Rewrites a generated `instance` command to use `scoped instance` or `local instance`
+    by patching the `attrKind` node in the syntax tree (declaration → instance → attrKind). -/
 private def setInstanceVisibility (cmd : TSyntax `command) (kind : AttributeKind) : TSyntax `command :=
   if kind == .global then cmd
   else

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1922,7 +1922,7 @@ a term describing the constraint. Entries in the same SCC are compiled into a sh
     Later entries can use instances derived by earlier ones.
     Each entry can optionally be prefixed with a sort keyword (default: generator). -/
 syntax mutualEntry := ("generator" <|> "enumerator" <|> "checker")? term
-syntax (name := mutual_deriver) "derive_mutual" mutualEntry,+ : command
+syntax (name := mutual_deriver) Term.attrKind "derive_mutual" mutualEntry,+ : command
 
 /-- Derives a constrained producer instance directly from a ScheduleDep,
     without going through syntax parsing. Returns the instance command. -/
@@ -1969,12 +1969,25 @@ def deriveFromScheduleDep (dep : ScheduleDep) (scheduleRewriter : List ScheduleS
       dep.inductiveName indLevels freshArgIdents freshenedOutputNames.toList
       outTypes.toList producerSort localCtx
 
+private def setInstanceVisibility (cmd : TSyntax `command) (kind : AttributeKind) : TSyntax `command :=
+  if kind == .global then cmd
+  else
+    let raw := cmd.raw
+    let instNode := raw[1]
+    let attrKindNode := instNode[0]
+    let newOptChild := match kind with
+      | .global => mkNullNode
+      | .scoped => mkNullNode #[mkNode ``Lean.Parser.Term.scoped #[mkAtom "scoped"]]
+      | .local => mkNullNode #[mkNode ``Lean.Parser.Term.local #[mkAtom "local"]]
+    let newAttrKind := attrKindNode.setArg 0 newOptChild
+    let newInstNode := instNode.setArg 0 newAttrKind
+    ⟨raw.setArg 1 newInstNode⟩
+
 @[command_elab mutual_deriver]
 def elabDeriveMutual : CommandElab := fun stx => do
-  match stx with
-  | `(derive_mutual $entries,*) => do
-    withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
-      let specEntries := entries.getElems
+  let attrKind ← liftMacroM (Lean.Elab.toAttributeKind stx[0])
+  let specEntries := stx[2].getSepArgs
+  withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
 
       -- Step 1: Parse all specs to get (inductiveName, outputIdxs, deriveSort) and assign global def names
       let mut specMeta : Array (Name × List Nat × Name × DeriveSort) := #[]
@@ -1982,13 +1995,13 @@ def elabDeriveMutual : CommandElab := fun stx => do
         let entry := specEntries[i]!
         -- Parse the optional sort keyword from the mutualEntry syntax
         let (deriveSort, termStx) : DeriveSort × (TSyntax `term) := Id.run do
-          let children := entry.raw.getArgs
+          let children : Array Syntax := entry.getArgs
           -- mutualEntry = ("generator" | "enumerator" | "checker")? term
           -- If keyword present: children[0] is the keyword, children[1] is the term
           -- If no keyword: children[0] is empty, children[1] is the term (or just the term)
           if children.size >= 2 then
-            let kw := children[0]!
-            let tm := children[1]!
+            let kw : Syntax := children[0]!
+            let tm : Syntax := children[1]!
             if kw.isOfKind `null && kw.getArgs.isEmpty then
               (.Generator, ⟨tm⟩)
             else
@@ -1997,7 +2010,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 else .Generator
               (sort, ⟨tm⟩)
           else
-            (.Generator, ⟨entry.raw⟩)
+            (.Generator, ⟨entry⟩)
         let (indName, outIdxs) ← liftTermElabM do
           let e ← elabTerm termStx .none
           lambdaTelescope e fun _args body => do
@@ -2688,7 +2701,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
             if !richOutput then logInfo m!"  ● {specDescs.head!}"
             elabCommand defCmds[0]!
           for instCmd in instCmds do
-            elabCommand instCmd
+            elabCommand (setInstanceVisibility instCmd attrKind)
       else
         -- Fallback: no auto-derive, use old per-entry compilation
         let siblings := specMeta.toList
@@ -2698,8 +2711,8 @@ def elabDeriveMutual : CommandElab := fun stx => do
           let rawEntry := specEntries[i]!
           -- Extract term from mutualEntry syntax (skip optional keyword)
           let termStx : TSyntax `term := Id.run do
-            let children := rawEntry.raw.getArgs
-            if children.size >= 2 then ⟨children[1]!⟩ else ⟨rawEntry.raw⟩
+            let children : Array Syntax := rawEntry.getArgs
+            if children.size >= 2 then ⟨children[1]!⟩ else ⟨rawEntry⟩
           let (_, _, globalName, _) := specMeta[i]!
           let rewriter := fun steps => rewriteMutualCalls steps siblings
           let (defCmd, instCmd) ← liftTermElabM do
@@ -2715,5 +2728,4 @@ def elabDeriveMutual : CommandElab := fun stx => do
         let mutualCmd ← `(command| mutual $defCmds* end)
         elabCommand mutualCmd
         for instCmd in instCmds do
-          elabCommand instCmd
-  | _ => throwUnsupportedSyntax
+          elabCommand (setInstanceVisibility instCmd attrKind)

--- a/Specimen/README.md
+++ b/Specimen/README.md
@@ -58,6 +58,29 @@ derive_mutual checker
   (fun Γ e τ => typing Γ e τ)
 ```
 
+**Instance visibility**: By default, `derive_mutual` registers global instances. You can prefix with `scoped` or `local` to control visibility:
+
+```lean
+-- Scoped: instance only visible when namespace is opened
+namespace MyStrategy
+scoped derive_mutual
+  (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
+end MyStrategy
+
+-- Use it explicitly:
+open MyStrategy in #eval ...
+
+-- Local: instance only visible within the enclosing section
+section
+local derive_mutual
+  (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
+-- instance available here
+end
+-- instance gone here
+```
+
+This enables A/B comparison of scoring strategies by deriving the same relation under different namespaces with different `specimen.scoreType` options.
+
 **How `autoDeriveDeps` works**: When enabled, `derive_mutual` inspects the constructors of the target relation and automatically derives generator/checker instances for any sub-relations (e.g., `typing` depends on `lookup` — both will be derived). This eliminates the need to manually derive dependencies first.
 
 **How `multiOutput` works**: When enabled, hypothesis steps can produce multiple output variables simultaneously. For instance, a hypothesis `typing Γ e τ` can generate both `e` and `τ` in a single step (producing a `Prod`), rather than requiring separate steps.

--- a/SpecimenTest/ScopedInstanceTest.lean
+++ b/SpecimenTest/ScopedInstanceTest.lean
@@ -1,0 +1,45 @@
+import Plausible.Gen
+import Specimen.DecOpt
+import Specimen.ArbitrarySizedSuchThat
+import Specimen.DeriveConstrainedProducer
+import SpecimenTest.CommonDefinitions.BinaryTree
+import SpecimenTest.DeriveDecOpt.DeriveBSTChecker
+
+/-! Test: scoped and local instance visibility for `derive_mutual`.
+    Demonstrates that the same relation can be derived with different strategies
+    in separate namespaces without global conflicts (issue #43). -/
+
+open Plausible
+
+deriving instance Arbitrary for BinaryTree
+
+namespace Strategy.A
+
+set_option specimen.autoDeriveDeps true in
+scoped derive_mutual
+  (fun (lo hi : Nat) => ∃ (t : BinaryTree), BST lo hi t)
+
+end Strategy.A
+
+namespace Strategy.B
+
+set_option specimen.autoDeriveDeps true in
+scoped derive_mutual
+  (fun (lo hi : Nat) => ∃ (t : BinaryTree), BST lo hi t)
+
+end Strategy.B
+
+-- Without opening either namespace, instance synthesis should fail
+#check_failure (inferInstance : ArbitrarySizedSuchThat BinaryTree (fun t => BST 0 10 t))
+
+-- Opening Strategy.A makes its instance available
+open Strategy.A in
+#check (inferInstance : ArbitrarySizedSuchThat BinaryTree (fun t => BST 0 10 t))
+
+-- Opening Strategy.B makes its instance available
+open Strategy.B in
+#check (inferInstance : ArbitrarySizedSuchThat BinaryTree (fun t => BST 0 10 t))
+
+-- Opening both is valid — Lean picks one by priority/order (no ambiguity error)
+open Strategy.A Strategy.B in
+#check (inferInstance : ArbitrarySizedSuchThat BinaryTree (fun t => BST 0 10 t))


### PR DESCRIPTION
## Summary

Closes #43.

- Adds `Term.attrKind` prefix to `derive_mutual` syntax, enabling `scoped derive_mutual` and `local derive_mutual` in addition to the existing global behavior
- Scoped instances are only visible when their namespace is opened; local instances are only visible within their enclosing section
- Enables A/B comparison of scoring strategies by deriving the same relation under different namespaces

## Usage

```lean
namespace Strategy.A
set_option specimen.scoreType "Scoring.SourceQualityScore" in
scoped derive_mutual
  (fun lo hi => ∃ t, BST lo hi t)
end Strategy.A

namespace Strategy.B
set_option specimen.scoreType "Scoring.DefaultScore" in
scoped derive_mutual
  (fun lo hi => ∃ t, BST lo hi t)
end Strategy.B

-- Use one:
open Strategy.A in #eval ...
```

## Test plan

- [x] `SpecimenTest.ScopedInstanceTest` verifies:
  - Instance synthesis fails without `open` (scoped correctly)
  - Each namespace's instance resolves independently with `open`
  - Opening both namespaces still resolves (no ambiguity error)
- [x] Existing `derive_mutual` tests pass unchanged (backward compatible)
- [x] `local derive_mutual` tested in isolation (instance disappears after `end` section)