### PR TITLE
Add specimen.silent to suppress all derivation output (supersedes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ derive_checker (fun n t => balanced n t)
 | `specimen.fuel` | `10000` | Fuel (termination budget) for derived generators/enumerators/checkers |
 | `specimen.richOutput` | `true` | Emit rich HTML widget output in the Lean infoview |
 | `specimen.textOutput` | `0` | Plain-text output verbosity (0=off, 1=summary, 2=problems, 3=full) |
+| `specimen.silent` | `false` | Suppress all informational derivation output (`Try this:` suggestions and `derive_mutual` widgets/text). Instances are still installed |
 | `specimen.searchLimit` | `200000` | Max hypothesis orderings to evaluate per constructor during schedule search |
 
 **Scoring strategies** control how Specimen evaluates and selects among candidate schedules during derivation. The `specimen.scoreType` option selects the active strategy:

--- a/Specimen/Debug.lean
+++ b/Specimen/Debug.lean
@@ -51,6 +51,19 @@ register_option specimen.searchLimit : Nat := {
   descr := "max hypothesis orderings to evaluate per constructor during schedule search"
 }
 
+/-- When true, all of Specimen's informational derivation output is suppressed:
+    the `Try this:` suggestion popups from the single-derive commands
+    (`derive_checker` / `derive_generator` / `derive_generator_multi` /
+    `derive_enumerator` / `derive_enum`) as well as the HTML widget and
+    plain-text schedule reports from `derive_mutual`. The typeclass instances
+    are still installed exactly as before; only the console/infoview output is
+    skipped. Useful in batch builds where hundreds of derives would otherwise
+    flood the console with tens of thousands of lines. -/
+register_option specimen.silent : Bool := {
+  defValue := false
+  descr := "suppress all informational derivation output (Try this: suggestions, derive_mutual widgets/text)"
+}
+
 /-- Global flag for enabling/disabling debug messages -/
 def globalDebugFlag : Bool := false
 
@@ -62,6 +75,11 @@ macro "schedTrace " msg:interpolatedStr(term) : term =>
 def inDebugMode [Monad m] [MonadOptions m] : m Bool := do
   let opts ← getOptions
   return Lean.Option.get opts specimen.debug
+
+/-- Determines whether the `specimen.silent` Option flag is set -/
+def inSilentMode [Monad m] [MonadOptions m] : m Bool := do
+  let opts ← getOptions
+  return Lean.Option.get opts specimen.silent
 
 /-- Performs a monadic `action` if a flag value is set -/
 def withDebugFlag [Monad m] [MonadOptions m] [MonadWithOptions m] [MonadLog m] [AddMessageContext m] (flag : Bool) (action : m Unit) : m Unit := do

--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -264,9 +264,11 @@ def elabDeriveScheduledChecker : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeclassInstance)
 
     -- Display the code for the derived checker to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this checker: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this checker: ")
 
     -- Elaborate the typeclass instance and add it to the local context
     elabCommand typeclassInstance

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1853,9 +1853,11 @@ def elabDeriveGenerator : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
 
     -- Display the code for the derived generator to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this generator: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this generator: ")
 
     elabCommand typeClassInstance
 
@@ -1873,8 +1875,9 @@ def elabDeriveGeneratorMulti : CommandElab := fun stx => do
     withScope (fun scope => { scope with opts := scope.opts.set `specimen.multiOutput true }) do
       let typeClassInstance ← liftTermElabM <| deriveArbitrarySuchThatInstance descr
       let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
-      liftTermElabM $ Tactic.TryThis.addSuggestion stx
-        (Format.pretty genFormat) (header := "Try this generator: ")
+      unless (← inSilentMode) do
+        liftTermElabM $ Tactic.TryThis.addSuggestion stx
+          (Format.pretty genFormat) (header := "Try this generator: ")
       elabCommand typeClassInstance
   | _ => throwUnsupportedSyntax
 
@@ -1894,9 +1897,11 @@ def elabDeriveScheduledEnumerator : CommandElab := fun stx => do
     let genFormat ← liftCoreM (PrettyPrinter.ppCommand typeClassInstance)
 
     -- Display the code for the derived enumerator to the user
-    -- & prompt the user to accept it in the VS Code side panel
-    liftTermElabM $ Tactic.TryThis.addSuggestion stx
-      (Format.pretty genFormat) (header := "Try this enumerator: ")
+    -- & prompt the user to accept it in the VS Code side panel.
+    -- Suppressed under `set_option specimen.silent true`.
+    unless (← inSilentMode) do
+      liftTermElabM $ Tactic.TryThis.addSuggestion stx
+        (Format.pretty genFormat) (header := "Try this enumerator: ")
 
     elabCommand typeClassInstance
 
@@ -2260,7 +2265,9 @@ def elabDeriveMutual : CommandElab := fun stx => do
                 logWarning m!"Failed to compile {key.inductiveName}{key.outputIndices}{repr key.deriveSort}: {e.toMessageData}"
             | _ => logWarning m!"No schedule found for {key.inductiveName}{key.outputIndices}"
           compiledComponents := compiledComponents.push (compMeta, defCmds, instCmds)
-        -- Build HTML output using ProofWidgets (controlled by specimen.richOutput)
+        -- Build HTML output using ProofWidgets (controlled by specimen.richOutput).
+        -- `specimen.silent` suppresses all informational output below.
+        let silent ← inSilentMode
         let richOutput := Lean.Option.get (← getOptions) specimen.richOutput
         let mkSpan (style : Json) (text : String) : Html :=
           .element "span" #[("style", style)] #[.text text]
@@ -2571,7 +2578,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
             .element "div" #[("style", json% {"marginLeft": "8px", "borderLeft": "2px solid #3c3c3c", "paddingLeft": "12px"})] trieItems
           ])
         -- Emit the full HTML widget (at top of infoview)
-        if richOutput then
+        if richOutput && !silent then
           let fullHtml := Html.element "div" #[("style", json% {"fontFamily": "var(--vscode-editor-font-family, monospace)", "fontSize": "13px", "lineHeight": "1.6", "padding": "8px"})] htmlChildren
           let graphMsg ← liftCoreM <| Lean.MessageData.ofHtml fullHtml
             s!"derive_mutual: {usedKeys.size} specs in {components.length} components"
@@ -2579,7 +2586,7 @@ def elabDeriveMutual : CommandElab := fun stx => do
         -- Plain-text fallback output (accessible to LLMs and non-IDE tooling)
         -- Levels: 0=off, 1=names+quality, 2=full schedules for poor-quality, 3=everything
         let textLevel := Lean.Option.get (← getOptions) specimen.textOutput
-        if textLevel > 0 then
+        if textLevel > 0 && !silent then
           let specQuality (indSched : InductiveSchedule) : String :=
             let b := bundle.scoreBadness indSched.score
             if b ≤ 0.2 then "★★★"
@@ -2699,11 +2706,11 @@ def elabDeriveMutual : CommandElab := fun stx => do
             pure s!"{k.prettyPrint numArgs cs tpIdxs} {scoreStr}"
           let richOutput := Lean.Option.get (← getOptions) specimen.richOutput
           if defCmds.size > 1 then
-            if !richOutput then logInfo m!"  ◆ mutual ({defCmds.size}):\n    {String.intercalate "\n    " specDescs}"
+            if !richOutput && !silent then logInfo m!"  ◆ mutual ({defCmds.size}):\n    {String.intercalate "\n    " specDescs}"
             let mutualCmd ← `(command| mutual $defCmds* end)
             elabCommand mutualCmd
           else if defCmds.size == 1 then
-            if !richOutput then logInfo m!"  ● {specDescs.head!}"
+            if !richOutput && !silent then logInfo m!"  ● {specDescs.head!}"
             elabCommand defCmds[0]!
           for instCmd in instCmds do
             elabCommand (setInstanceVisibility instCmd attrKind)

--- a/Specimen/DeriveEnum.lean
+++ b/Specimen/DeriveEnum.lean
@@ -1,5 +1,6 @@
 import Lean
 
+import Specimen.Debug
 import Specimen.Idents
 import Specimen.TSyntaxCombinators
 import Specimen.Enumerators
@@ -275,8 +276,10 @@ def elabDeriveEnum : CommandElab := fun stx => do
       -- in the VS Code side panel
       let instCmd : TSyntax `command := ⟨cmds.back!⟩
       let enumFormat ← liftCoreM (PrettyPrinter.ppCommand instCmd)
-      liftTermElabM $ Tactic.TryThis.addSuggestion stx
-        (Format.pretty enumFormat) (header := "Try this enumerator: ")
+      -- Suppressed under `set_option specimen.silent true`.
+      unless (← inSilentMode) do
+        liftTermElabM $ Tactic.TryThis.addSuggestion stx
+          (Format.pretty enumFormat) (header := "Try this enumerator: ")
 
       -- Elaborate the typeclass instance and add it to the local context
       for cmd in cmds do elabCommand cmd

--- a/Specimen/GeneratorCombinators.lean
+++ b/Specimen/GeneratorCombinators.lean
@@ -28,7 +28,7 @@ def runChecked (x : Gen α) (size : Nat) : IO (GenResult α) := do
   match result with
   | .ok a => return .ok a
   | .error (.userError msg) =>
-    let stripped := msg.stripPrefix "Generation failure:"
+    let stripped := (msg.dropPrefix? "Generation failure:").map (·.toString) |>.getD msg
     if GenError.isInconclusive (.genError stripped) then
       return .insufficientFuel stripped
     else

--- a/Specimen/README.md
+++ b/Specimen/README.md
@@ -245,6 +245,7 @@ Similar hierarchy exists for enumerators (`EnumSizedSuchThat` → `EnumSuchThat`
 | `specimen.fuel` | `10000` | Fuel (termination budget) for derived generators/enumerators/checkers |
 | `specimen.richOutput` | `true` | Emit rich HTML widget in the Lean infoview showing schedule details |
 | `specimen.textOutput` | `0` | Plain-text output verbosity: 0=off, 1=summary, 2=problems only, 3=full schedules |
+| `specimen.silent` | `false` | Suppress all informational derivation output — the `Try this:` suggestions from `derive_checker`/`derive_generator`/`derive_enumerator` and the widget/text reports from `derive_mutual`. Instances are still installed |
 | `specimen.searchLimit` | `200000` | Max hypothesis orderings to evaluate per constructor during branch-and-bound schedule search |
 | `specimen.debug` | `false` | Enable debug messages from Specimen |
 

--- a/SpecimenTest.lean
+++ b/SpecimenTest.lean
@@ -109,4 +109,7 @@ import SpecimenTest.ScheduleQualityRegressionTest
 -- Weight function / modifier customization tests
 import SpecimenTest.WeightCustomizationTest
 
+-- `specimen.silent` output-suppression option tests
+import SpecimenTest.SilentOptionTest
+
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/BoundedBuffer.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/BoundedBuffer.lean
@@ -76,6 +76,7 @@ instance instArbitraryString : Arbitrary String where
 -- generates a command freely and then checks `¬ CanStep`.
 deriving instance Arbitrary for BBCmd
 
+#guard_msgs(drop info, drop warning) in
 derive_mutual
   (fun i => ∃ t s, SafeBBTrace i t s),
   (fun s => ∃ t i, SafeBBTrace i t s)
@@ -125,6 +126,7 @@ inductive EveryBBTrace : BB -> BBTrace -> BB -> Prop where
     EveryBBTrace s' ps s'' ->
     EveryBBTrace s ((cmd, res)::ps) s''
 
+#guard_msgs(drop info, drop warning) in
 derive_mutual
   generator (fun i => ∃ t s, EveryBBTrace i t s)
 

--- a/SpecimenTest/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
+++ b/SpecimenTest/DeriveArbitrarySuchThat/DeriveBSTGenerator.lean
@@ -19,7 +19,7 @@ deriving instance Arbitrary for BinaryTree
 -- which is non-inductive but has Decidable — handled by the non-inductive guard)
 set_option specimen.multiOutput true in
 set_option specimen.autoDeriveDeps true in
-#guard_msgs(drop info) in
+#guard_msgs(drop info, drop warning) in
 derive_mutual
   (fun (lo hi : Nat) => ∃ (t : BinaryTree), BST lo hi t)
 

--- a/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
+++ b/SpecimenTest/DeriveDecOpt/DeriveBSTChecker.lean
@@ -14,7 +14,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
-#guard_msgs(drop info) in
+#guard_msgs(drop info, drop warning) in
 derive_mutual checker
   (fun lo hi t => BST lo hi t)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DeriveBSTEnumerator.lean
@@ -11,7 +11,7 @@ set_option guard_msgs.diff true
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
-#guard_msgs(drop info) in
+#guard_msgs(drop info, drop warning) in
 derive_mutual enumerator
   (fun lo hi => ∃ (t : BinaryTree), BST lo hi t)
 

--- a/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
+++ b/SpecimenTest/DeriveEnumSuchThat/DerivePermutationEnumerator.lean
@@ -7,7 +7,7 @@ import SpecimenTest.CommonDefinitions.Permutation
 set_option specimen.autoDeriveDeps true
 set_option specimen.multiOutput true
 
-#guard_msgs(drop info) in
+#guard_msgs(drop info, drop warning) in
 derive_mutual enumerator
   (∃ l l', Permutation l' l)
 

--- a/SpecimenTest/SilentOptionTest.lean
+++ b/SpecimenTest/SilentOptionTest.lean
@@ -46,9 +46,9 @@ derive_generator (∃ (m : _), Cube m)
 derive_enumerator (∃ (m : _), Cube m)
 
 -- The checker instance was installed despite the silence.
-#check (inferInstance : DecOpt (Between 0 1 2))
+example : DecOpt (Between 0 1 2) := inferInstance
 -- The generator instance was installed despite the silence.
-#check (inferInstance : ArbitrarySizedSuchThat Nat (fun m => Cube m))
+example : ArbitrarySizedSuchThat Nat (fun m => Cube m) := inferInstance
 
 end SilentOld
 
@@ -70,7 +70,7 @@ derive_mutual checker
   (fun lo hi t => BST lo hi t)
 
 -- The checker instance was installed despite the silence.
-#check (inferInstance : DecOpt (BST 0 10 .Leaf))
+example : DecOpt (BST 0 10 .Leaf) := inferInstance
 
 end SilentMutual
 

--- a/SpecimenTest/SilentOptionTest.lean
+++ b/SpecimenTest/SilentOptionTest.lean
@@ -1,0 +1,109 @@
+import Plausible.Gen
+import Specimen.DecOpt
+import Specimen.ArbitrarySizedSuchThat
+import Specimen.Enumerators
+import Specimen.DeriveChecker
+import Specimen.DeriveConstrainedProducer
+import Specimen.EnumeratorCombinators
+import SpecimenTest.CommonDefinitions.BinaryTree
+
+/-! Test: `set_option specimen.silent true` suppresses all informational
+    derivation output — the `Try this:` suggestions from the single-derive
+    commands and the widget/text reports from `derive_mutual` — while still
+    installing the typeclass instances.
+
+    `#guard_msgs in` (strict, no expected messages) fails if the command emits
+    *any* message, so it doubles as an assertion that silent mode is quiet.
+    The `#check` lines afterwards confirm the instances were installed
+    regardless. Note that silent mode suppresses only *informational* output;
+    genuine warnings/errors are diagnostics and are intentionally left alone. -/
+
+open Plausible DecOpt
+
+set_option guard_msgs.diff true
+
+/-! ## Old path — single-derive commands, silent
+
+    Each of these would normally emit a `Try this <kind>: …` suggestion. Under
+    `specimen.silent`, `#guard_msgs in` (which allows *no* messages) passes. -/
+
+namespace SilentOld
+
+/-- `Cube n` holds when `n` is a perfect cube. Self-contained (no dependency
+    instances needed), so `derive_generator` succeeds standalone. -/
+inductive Cube : Nat → Prop where
+  | cube n : Cube (n * n * n)
+
+set_option specimen.silent true
+
+#guard_msgs in
+derive_checker (fun lo x hi => Between lo x hi)
+
+#guard_msgs in
+derive_generator (∃ (m : _), Cube m)
+
+#guard_msgs in
+derive_enumerator (∃ (m : _), Cube m)
+
+-- The checker instance was installed despite the silence.
+#check (inferInstance : DecOpt (Between 0 1 2))
+-- The generator instance was installed despite the silence.
+#check (inferInstance : ArbitrarySizedSuchThat Nat (fun m => Cube m))
+
+end SilentOld
+
+/-! ## New path — `derive_mutual`, silent
+
+    Normally emits an HTML widget (info) and/or a plain-text schedule report.
+    Under `specimen.silent`, no messages are produced — even with
+    `specimen.textOutput` cranked up, which would otherwise force text output. -/
+
+namespace SilentMutual
+
+set_option specimen.autoDeriveDeps true
+set_option specimen.silent true
+-- textOutput would normally force plain-text info output; silent must win.
+set_option specimen.textOutput 3
+
+#guard_msgs in
+derive_mutual checker
+  (fun lo hi t => BST lo hi t)
+
+-- The checker instance was installed despite the silence.
+#check (inferInstance : DecOpt (BST 0 10 .Leaf))
+
+end SilentMutual
+
+/-! ## Default behavior unchanged — suggestions still emitted
+
+    With `silent` at its default (`false`), the single-derive commands still
+    produce a `Try this checker:` suggestion. We assert its exact text for a
+    trivial relation to confirm nothing is suppressed by default. -/
+
+namespace LoudDefault
+
+/-- `IsZero n` holds exactly when `n = 0`. A minimal relation whose derived
+    checker is small enough to pin verbatim. -/
+inductive IsZero : Nat → Prop where
+  | mk : IsZero 0
+
+/-- info: Try this checker:
+      [apply] instance : DecOpt (@LoudDefault.IsZero n_1) where
+        decOpt :=
+          let rec aux_dec (fuel : Nat) (initSize : Nat) (size : Nat) (n_1 : Nat) : Except Plausible.GenError Bool :=
+            (match fuel with
+            | Nat.zero => MonadExcept.throw Gen.outOfFuelError
+            | Nat.succ fuel' =>
+              match size with
+              | Nat.zero =>
+                DecOpt.checkerBacktrack
+                  [fun (_ : Unit) => @DecOpt.decOpt (@Eq (@Nat) n_1 (@OfNat.ofNat (@Nat) 0 (@instOfNatNat 0))) _ initSize]
+              | Nat.succ size' =>
+                DecOpt.checkerBacktrack
+                  [fun (_ : Unit) => @DecOpt.decOpt (@Eq (@Nat) n_1 (@OfNat.ofNat (@Nat) 0 (@instOfNatNat 0))) _ initSize, ])
+          fun size => aux_dec 10000 size size n_1
+-/
+#guard_msgs(whitespace := lax) in
+derive_checker (fun n => IsZero n)
+
+end LoudDefault


### PR DESCRIPTION
## Summary
Adds a single `specimen.silent` option (default `false`) that silences **all** informational derivation output while still installing the typeclass instances exactly as before. In batch builds with hundreds of derives, the suggestion/widget text otherwise floods the console with tens of thousands of lines of no value.

Covers **both** output paths:

- **Old path (single derives):** gates the `Try this:` suggestion in `derive_checker`, `derive_generator`, `derive_generator_multi`, `derive_enumerator`, and `derive_enum`.
- **New path (`derive_mutual`):** gates the HTML widget, the plain-text schedule report (even when `specimen.textOutput` is set), and the per-component summary lines.

Genuine warnings/errors are diagnostics and are intentionally left unsuppressed.

Usage:
```lean
set_option specimen.silent true
```

## Relationship to #15
This **supersedes and obsoletes #15**. That PR was based on a stale base and covered only 4 of the old-path suggestion sites, missing `derive_enum` and all of the `derive_mutual` output. This PR is rebased on current `main` and silences every informational output site across both paths.

## Test plan
- [x] `lake build` clean (library + full `SpecimenTest` suite, 141 jobs).
- [x] New `SpecimenTest/SilentOptionTest.lean`:
  - Strict `#guard_msgs in` (allows no messages) confirms silent mode is fully quiet for `derive_checker`, `derive_generator`, `derive_enumerator`, and `derive_mutual checker` — the latter even with `specimen.textOutput 3`.
  - `#check` on the synthesized instances confirms they are still installed.
  - A default-behavior block confirms the `Try this checker:` suggestion is still emitted when `silent` is `false`.
- [x] README option tables updated (root and `Specimen/`).