### PR TITLE
Fix checker/enumerator soundness: base-case failsafe returns inconclusive, not false

### DIFF
--- a/Specimen/DeriveChecker.lean
+++ b/Specimen/DeriveChecker.lean
@@ -201,9 +201,12 @@ def deriveScheduledChecker' (_args : Array Expr)
       -- For checkers with recursive constructors, add a failsafe to the base case:
       -- if no base constructor matches, return "unknown" (error) rather than "false",
       -- since a recursive constructor might succeed at a larger size.
+      -- Uses `outOfFuelError` (not `genericFailure`) so that `isInconclusiveError`
+      -- recognizes it as inconclusive; otherwise the failsafe reads as a definitive
+      -- "false" and the checker reports false negatives from partial enumeration.
       let baseCheckersWithFailsafe ← do
         if !recursiveCheckers.isEmpty then
-          let failsafe ← `((fun (_ : $(Lean.mkIdent ``Unit)) => $failFn $genericFailure))
+          let failsafe ← `((fun (_ : $(Lean.mkIdent ``Unit)) => $failFn $(mkIdent ``Gen.outOfFuelError)))
           pure (nonRecursiveCheckers.push failsafe)
         else
           pure nonRecursiveCheckers

--- a/Specimen/DeriveConstrainedProducer.lean
+++ b/Specimen/DeriveConstrainedProducer.lean
@@ -1301,14 +1301,17 @@ def compileInductiveSchedule (indSched : InductiveSchedule)
     -- For checkers/enumerators with recursive constructors, add a failsafe to the base case:
     -- if no base constructor matches, return "unknown" (error) rather than "false",
     -- since a recursive constructor might succeed at a larger size.
+    -- Uses `outOfFuelError` (not `genericFailure`) so that `isInconclusiveError`
+    -- recognizes it as inconclusive; otherwise the failsafe reads as a definitive
+    -- "false" and the checker reports false negatives from partial enumeration.
     let baseProducersWithFailsafe ← do
       if !recursiveProducers.isEmpty then
         match key.deriveSort with
         | .Checker | .Theorem =>
-          let failsafe ← `((fun (_ : Unit) => $failFn $genericFailure))
+          let failsafe ← `((fun (_ : Unit) => $failFn $(mkIdent ``Gen.outOfFuelError)))
           pure (nonRecursiveProducers.push failsafe)
         | .Enumerator =>
-          let failsafe ← `($failFn $genericFailure)
+          let failsafe ← `($failFn $(mkIdent ``Gen.outOfFuelError))
           pure (nonRecursiveProducers.push failsafe)
         | .Generator => pure nonRecursiveProducers
       else


### PR DESCRIPTION
## What

When a checker or enumerator has recursive constructors and no base constructor matches at the current size, the base-case failsafe was returning `genericFailure`. But `isInconclusiveError` (`EnumeratorCombinators.lean:62`) treats `genericFailure` as a definitive **false**, while `Gen.outOfFuelError` is recognized as **inconclusive**.

Since a recursive constructor might still succeed at a larger size, the old failsafe could report a **false negative** from partial enumeration — the checker says "false" when the correct answer is "unknown (out of fuel)".

## Change

Switch both failsafe sites from `genericFailure` to `Gen.outOfFuelError`:

- `Specimen/DeriveChecker.lean` — single `derive_checker` path
- `Specimen/DeriveConstrainedProducer.lean` — `derive_mutual` checker / enumerator / theorem path (`.Checker | .Theorem` and `.Enumerator` cases)

Four lines of behavioral change, plus explanatory comments at each site.

## Testing

- `lake build` passes clean (47 jobs).
- Full snapshot suite green.

This hardening is a prerequisite for the theorem-checking path, where an inconclusive base case must not be misread as a disproof.